### PR TITLE
Import coordinates and CO

### DIFF
--- a/tomo/protocols/protocol_base.py
+++ b/tomo/protocols/protocol_base.py
@@ -24,10 +24,16 @@
 # *
 # **************************************************************************
 
+
+import re
+from os.path import join
+
 import pyworkflow as pw
 import pyworkflow.em as pwem
 from pyworkflow.protocol.params import PointerParam
 from pyworkflow.mapper.sqlite_db import SqliteDb
+from pyworkflow.utils.properties import Message
+from pyworkflow.utils.path import expandPattern
 
 import tomo.objects
 
@@ -91,7 +97,7 @@ class ProtTomoReconstruct(pwem.EMProtocol, ProtTomoBase):
     """ Base class for Tomogram reconstruction protocols. """
     pass
 
-class ProtTomoPicking(pwem.EMProtocol, ProtTomoBase):
+class ProtTomoPicking(pwem.ProtImport, ProtTomoBase):
 
     OUTPUT_PREFIX = 'output3DCoordinates'
 
@@ -102,6 +108,53 @@ class ProtTomoPicking(pwem.EMProtocol, ProtTomoBase):
         form.addParam('inputTomogram', PointerParam, label="Input Tomogram", important=True,
                       pointerClass='Tomogram',
                       help='Select the Tomogram to be used during picking.')
+
+
+class ProtTomoImportFiles(pwem.ProtImportFiles, ProtTomoBase):
+
+    def _defineParams(self, form):
+        self._defineImportParams(form)
+
+        self._defineAcquisitionParams(form)
+
+    def _defineImportParams(self, form):
+        """ Override to add options related to the different types
+        of import that are allowed by each protocol.
+        """
+        form.addSection(label='Import')
+        form.addParam('filesPath', pwem.params.PathParam,
+                      label="Files directory",
+                      help="Directory with the files you want to import.\n\n"
+                           "The path can also contain wildcards to select"
+                           "from several folders. \n\n"
+                           "Examples:\n"
+                           "  ~/Particles/data/day??_micrographs/\n"
+                           "Each '?' represents one unknown character\n\n"
+                           "  ~/Particles/data/day*_micrographs/\n"
+                           "'*' represents any number of unknown characters\n\n"
+                           "  ~/Particles/data/day#_micrographs/\n"
+                           "'#' represents one digit that will be used as "
+                           "micrograph ID\n\n"
+                           "NOTE: wildcard characters ('*', '?', '#') "
+                           "cannot appear in the actual path.)")
+        form.addParam('filesPattern', pwem.params.StringParam,
+                      label='Pattern',
+                      help="Pattern of the files to be imported.\n\n"
+                           "The pattern can contain standard wildcards such as\n"
+                           "*, ?, etc, or special ones like ### to mark some\n"
+                           "digits in the filename as ID.\n\n"
+                           "NOTE: wildcards and special characters "
+                           "('*', '?', '#', ':', '%') cannot appear in the "
+                           "actual path.")
+
+    def _defineAcquisitionParams(self, form):
+        """ Override to add options related to acquisition info.
+        """
+        form.addParam('samplingRate', pwem.params.FloatParam,
+                      label=Message.LABEL_SAMP_RATE)
+
+    def _validate(self):
+        pass
 
 
 

--- a/tomo/protocols/protocol_import_coordinates.py
+++ b/tomo/protocols/protocol_import_coordinates.py
@@ -1,0 +1,169 @@
+# coding=utf-8
+# **************************************************************************
+# *
+# * Authors:     Adrian Quintana (adrian@eyeseetea.com) [1]
+# *
+# * [1] EyeSeeTea Ltd, London, UK
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from os.path import basename
+
+import pyworkflow.protocol.params as params
+from pyworkflow.utils import importFromPlugin
+
+from .protocol_base import ProtTomoImportFiles
+
+
+class ProtImportCoordinates3D(ProtTomoImportFiles):
+    """Protocol to import a set of tomograms to the project"""
+    _outputClassName = 'SetOfCoordinates3D'
+    _label = 'import set of coordinates 3D'
+
+    IMPORT_FROM_AUTO = 0
+    IMPORT_FROM_XMIPP = 1
+    IMPORT_FROM_RELION = 2
+    IMPORT_FROM_EMAN = 3
+    IMPORT_FROM_DOGPICKER = 4
+
+    def _getImportChoices(self):
+        """ Return a list of possible choices
+        from which the import can be done.
+        (usually packages formats such as: xmipp3, eman2, relion...etc.
+        """
+        return ['eman']
+
+    def __init__(self, **args):
+        ProtTomoImportFiles.__init__(self, **args)
+
+
+    def _defineParams(self, form):
+        ProtTomoImportFiles._defineParams(self, form)
+        form.addParam('boxSize', params.IntParam, label='Box size')
+
+        form.addParam('importTomogram', params.PointerParam,
+                      pointerClass='Tomogram',
+                      label='Input tomogram',
+                      help='Select the tomogram for which you '
+                            'want to import coordinates.')
+
+    def _insertAllSteps(self):
+        self._insertFunctionStep('importCoordinatesStep',
+                                 self.samplingRate.get())
+
+    # --------------------------- STEPS functions -----------------------------
+
+    def importCoordinatesStep(self, samplingRate):
+        importTomogram = self.importTomogram.get()
+        coordsSet = self._createSetOfCoordinates3D(importTomogram)
+        coordsSet.setBoxSize(self.boxSize.get())
+        ci = self.getImportClass()
+        for coordFile, fileId in self.iterFiles():
+            if importTomogram is not None:
+                def addCoordinate(coord):
+                    coord.setVolume(importTomogram)
+                    coordsSet.append(coord)
+
+                # Parse the coordinates in the given format for this micrograph
+                ci.importCoordinates3D(coordFile, addCoordinate)
+
+        self._defineOutputs(outputCoordinates=coordsSet)
+        self._defineSourceRelation(self.importTomogram, coordsSet)
+
+    # --------------------------- INFO functions ------------------------------
+    def _hasOutput(self):
+        return (self.hasAttribute('outputSubTomogram')
+                or self.hasAttribute('outputSubTomograms'))
+
+    def _getSubTomMessage(self):
+        if self.hasAttribute('outputSubTomogram'):
+            return "SubTomogram %s" % self.getObjectTag('outputSubTomogram')
+        else:
+            return "SubTomograms %s" % self.getObjectTag('outputSubTomograms')
+
+    def _summary(self):
+        summary = []
+        if self._hasOutput():
+            summary.append("%s imported from:\n%s"
+                           % (self._getSubTomMessage(), self.getPattern()))
+
+            summary.append(u"Sampling rate: *%0.2f* (Å/px)" %
+                           self.samplingRate.get())
+        return summary
+
+    def _methods(self):
+        methods = []
+        if self._hasOutput():
+            methods.append(" %s imported with a sampling rate *%0.2f*" %
+                           (self._getSubTomMessage(), self.samplingRate.get()),)
+        return methods
+
+    def _getVolumeFileName(self, fileName, extension=None):
+        if extension is not None:
+            baseFileName="import_" + basename(fileName).split(".")[0] + ".%s"%extension
+        else:
+            baseFileName="import_" + basename(fileName).split(":")[0]
+
+        return self._getExtraPath(baseFileName)
+
+    # ------------------ UTILS functions --------------------------------------
+    def getImportFrom(self):
+        importFrom = self.importFrom.get()
+        if importFrom == self.IMPORT_FROM_AUTO:
+            importFrom = self.getFormat()
+        return importFrom
+
+    def getImportClass(self):
+        """ Return the class in charge of importing the files. """
+        filesPath = self.filesPath.get()
+        importFrom = self.getImportFrom()
+
+        if importFrom == self.IMPORT_FROM_XMIPP:
+            XmippImport = importFromPlugin('xmipp3.convert', 'XmippImport',
+                                           'Xmipp is needed to import .xmd files',
+                                           doRaise=True)
+            return XmippImport(self, filesPath)
+
+        elif importFrom == self.IMPORT_FROM_RELION:
+            RelionImport = importFromPlugin('relion.convert', 'RelionImport',
+                                            errorMsg='Relion is needed to import .star files',
+                                            doRaise=True)
+            return RelionImport(self, filesPath)
+
+        elif importFrom == self.IMPORT_FROM_EMAN:
+            EmanImport = importFromPlugin('eman2.convert', 'EmanImport',
+                                          errorMsg='Eman is needed to import .json or '
+                                                   '.box files',
+                                          doRaise=True)
+            return EmanImport(self, None)
+
+        elif importFrom == self.IMPORT_FROM_DOGPICKER:
+            DogpickerImport = importFromPlugin('appion.convert', 'DogpickerImport',
+                                               errorMsg='appion plugin is needed to import '
+                                                        'dogpicker files',
+                                               doRaise=True)
+            return DogpickerImport(self)
+        else:
+            self.importFilePath = ''
+            return None
+
+
+

--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -29,6 +29,7 @@ from os.path import abspath, basename
 
 from pyworkflow.em import ImageHandler
 from pyworkflow.em.data import Transform
+import pyworkflow.protocols.params as params
 from pyworkflow.utils.path import createAbsLink
 
 from .protocol_base import ProtTomoImportFiles
@@ -42,6 +43,22 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
 
     def __init__(self, **args):
         ProtTomoImportFiles.__init__(self, **args)
+
+    def _defineParams(self, form):
+        ProtTomoImportFiles._defineParams(self, form)
+
+        form.addParam('importCoordinates', params.PointerParam,
+                      pointerClass='SetOfCoordinates3D',
+                      label='Input coordinates 3D',
+                      help='Select the coordinates for which the '
+                            'subtomograms were extracted.')
+
+    def _getImportChoices(self):
+        """ Return a list of possible choices
+        from which the import can be done.
+        (usually packages formats such as: xmipp3, eman2, relion...etc.
+        """
+        return ['eman2']
 
     def _insertAllSteps(self):
         self._insertFunctionStep('importSubTomogramsStep',
@@ -98,6 +115,7 @@ class ProtImportSubTomograms(ProtTomoImportFiles):
                     subtomo.cleanObjId()
                     subtomo.setLocation(index, newFileName)
                     subtomoSet.append(subtomo)
+                subtomoSet.setCoordinates3D(self.importCoordinates)
 
         if subtomoSet.getSize() > 1:
             self._defineOutputs(outputSubTomograms=subtomoSet)

--- a/tomo/protocols/protocol_import_tomograms.py
+++ b/tomo/protocols/protocol_import_tomograms.py
@@ -25,35 +25,34 @@
 # *
 # **************************************************************************
 
-from os.path import abspath
+from os.path import abspath, basename
 
-import pyworkflow.em as pwem
 from pyworkflow.em import ImageHandler
 from pyworkflow.em.data import Transform
-from pyworkflow.em.convert import Ccp4Header
 from pyworkflow.utils.path import createAbsLink
 
-from .protocol_base import ProtTomoBase
+
+from .protocol_base import ProtTomoImportFiles
 from tomo.objects import Tomogram
 
 
-class ProtImportTomograms(pwem.ProtImportVolumes, ProtTomoBase):
+class ProtImportTomograms(ProtTomoImportFiles):
     """Protocol to import a set of tomograms to the project"""
     _outputClassName = 'SetOfTomograms'
     _label = 'import tomograms'
 
     def __init__(self, **args):
-        pwem.ProtImportVolumes.__init__(self, **args)
+        ProtTomoImportFiles.__init__(self, **args)
 
     def _insertAllSteps(self):
         self._insertFunctionStep('importTomogramsStep',
                                  self.getPattern(),
-                                 self.samplingRate.get(),
-                                 self.setOrigCoord.get())
+                                 self.samplingRate.get())
+
 
     # --------------------------- STEPS functions -----------------------------
 
-    def importTomogramsStep(self, pattern, samplingRate, setOrigCoord=False):
+    def importTomogramsStep(self, pattern, samplingRate):
         """ Copy images matching the filename pattern
         Register other parameters.
         """
@@ -80,25 +79,18 @@ class ProtImportTomograms(pwem.ProtImportVolumes, ProtTomoBase):
             else:
                 zDim = z
             origin = Transform()
-            if setOrigCoord:
-                origin.setShiftsTuple(self._getOrigCoord())
-            else:
-                origin.setShifts(x/-2. * samplingRate,
-                            y/-2. * samplingRate,
-                            zDim/-2. * samplingRate)
+
+            origin.setShifts(x/-2. * samplingRate,
+                        y/-2. * samplingRate,
+                        zDim/-2. * samplingRate)
 
             tomo.setOrigin(origin)  # read origin from form
 
-            if self.copyFiles or setOrigCoord:
-                newFileName = abspath(self._getVolumeFileName(fileName, "mrc"))
-                Ccp4Header.fixFile(fileName, newFileName, origin.getShifts(),
-                                   samplingRate, Ccp4Header.ORIGIN)
-            else:
-                newFileName = abspath(self._getVolumeFileName(fileName))
+            newFileName = abspath(self._getVolumeFileName(fileName))
 
-                if fileName.endswith(':mrc'):
-                    fileName = fileName[:-4]
-                createAbsLink(fileName, newFileName)
+            if fileName.endswith(':mrc'):
+                fileName = fileName[:-4]
+            createAbsLink(fileName, newFileName)
             if n == 1:
                 tomo.cleanObjId()
                 tomo.setFileName(newFileName)
@@ -142,5 +134,11 @@ class ProtImportTomograms(pwem.ProtImportVolumes, ProtTomoBase):
                            (self._getTomMessage(), self.samplingRate.get()),)
         return methods
 
-    def _getOrigCoord(self):
-        return -1.*self.x.get(), -1.*self.y.get(), -1.*self.z.get()
+    def _getVolumeFileName(self, fileName, extension=None):
+        if extension is not None:
+            baseFileName="import_" + basename(fileName).split(".")[0] + ".%s"%extension
+        else:
+            baseFileName="import_" + basename(fileName).split(":")[0]
+
+        return self._getExtraPath(baseFileName)
+

--- a/tomo/protocols/protocol_import_tomograms.py
+++ b/tomo/protocols/protocol_import_tomograms.py
@@ -44,6 +44,13 @@ class ProtImportTomograms(ProtTomoImportFiles):
     def __init__(self, **args):
         ProtTomoImportFiles.__init__(self, **args)
 
+    def _getImportChoices(self):
+        """ Return a list of possible choices
+        from which the import can be done.
+        (usually packages formats such as: xmipp3, eman2, relion...etc.
+        """
+        return ['eman2']
+
     def _insertAllSteps(self):
         self._insertFunctionStep('importTomogramsStep',
                                  self.getPattern(),

--- a/tomo/viewers/viewer_tomograms.py
+++ b/tomo/viewers/viewer_tomograms.py
@@ -56,7 +56,7 @@ class ViewerProtImportTomograms(ProtocolViewer):
         form.addSection(label='Visualization of input tomograms')
         form.addParam('displayTomo', params.EnumParam,
                       choices=['chimera', 'slices'],
-                      default=TOMOGRAM_SLICES,
+                      default=TOMOGRAM_CHIMERA,
                       display=params.EnumParam.DISPLAY_HLIST,
                       label='Display tomogram with',
                       help='*chimera*: display tomograms as surface with '
@@ -73,10 +73,6 @@ class ViewerProtImportTomograms(ProtocolViewer):
             if views:
                 for v in views:
                     v.show()
-
-    # def _visualize(self, obj, **kwargs):
-    #     if not hasattr(self.protocol, 'outputTomogram'):
-    #         return self._showTomogramsSlices()
 
     def _getVisualizeDict(self):
         return {

--- a/tomo/viewers/viewer_tomograms.py
+++ b/tomo/viewers/viewer_tomograms.py
@@ -56,7 +56,7 @@ class ViewerProtImportTomograms(ProtocolViewer):
         form.addSection(label='Visualization of input tomograms')
         form.addParam('displayTomo', params.EnumParam,
                       choices=['chimera', 'slices'],
-                      default=TOMOGRAM_CHIMERA,
+                      default=TOMOGRAM_SLICES,
                       display=params.EnumParam.DISPLAY_HLIST,
                       label='Display tomogram with',
                       help='*chimera*: display tomograms as surface with '
@@ -64,6 +64,19 @@ class ViewerProtImportTomograms(ProtocolViewer):
                            'along z axis.\n If number of tomograms == 1, '
                            'a system of coordinates is shown'
                       )
+
+    def visualize(self, obj, **args):
+        if hasattr(self.protocol, 'outputTomogram'):
+            ProtocolViewer.visualize(self, obj, **args)
+        else:
+            views = self._showTomogramsSlices()
+            if views:
+                for v in views:
+                    v.show()
+
+    # def _visualize(self, obj, **kwargs):
+    #     if not hasattr(self.protocol, 'outputTomogram'):
+    #         return self._showTomogramsSlices()
 
     def _getVisualizeDict(self):
         return {
@@ -151,8 +164,8 @@ class ViewerProtImportTomograms(ProtocolViewer):
         # Write an sqlite with all tomograms selected for visualization.
         sampling, setOfObjects = self._createSetOfObjects()
 
-        if len(setOfObjects) == 1:
-            return [self.objectView(setOfObjects)]
+        view = self.objectView(setOfObjects)
+        view.setMemory(viewers.showj.getJvmMaxMemory() + 2)
 
         return [self.objectView(setOfObjects)]
 


### PR DESCRIPTION
- Implement import coordinates 3D (from eman for now but it is prepared to be expanded in the future with other packages)
- Remove parameters that make no sense in import tomograms and subtomograms: origin coordinates and streaming panel
- Implement ProtTomoImportFiles base class
- Only allow visualising single tomogram (not multiple) in Chimera 
- Allocate more memory for the tomogram viewer