### PR TITLE
Add sampling rate to SetOfCoordinates3D

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -87,7 +87,7 @@ class TiltSeriesBase(data.SetOfImages):
 
     def copyInfo(self, other):
         """ Copy basic information (id and other properties) but
-        not _mapperPath or _size from other set of micrographs to current one.
+        not _mapperPath or _size from other set of tomograms to current one.
         """
         self.copy(other, copyId=False, ignoreAttrs=['_mapperPath', '_size'])
 
@@ -483,7 +483,7 @@ class SetOfCoordinates3D(data.EMSet):
        self._samplingRate.set(sampling)
 
     def iterVolumes(self):
-        """ Iterate over the micrographs set associated with this
+        """ Iterate over the tomograms set associated with this
         set of coordinates.
         """
         return self.getVolumes()
@@ -516,14 +516,14 @@ class SetOfCoordinates3D(data.EMSet):
             yield coord
 
     def getVolumes(self):
-        """ Returns the SetOfMicrographs associated with
+        """ Returns the SetOfTomograms associated with
         this SetOfCoordinates"""
         return self._volumesPointer.get()
 
     def setVolumes(self, volumes):
-        """ Set the micrographs associated with this set of coordinates.
+        """ Set the tomograms associated with this set of coordinates.
         Params:
-            micrographs: Either a SetOfMicrographs object or a pointer to it.
+            tomograms: Either a SetOfTomograms object or a pointer to it.
         """
         if volumes.isPointer():
             self._volumesPointer.copy(volumes)

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -606,10 +606,22 @@ class AverageSubTomogram(SubTomogram):
 
 
 class ClassSubTomogram(SetOfSubTomograms):
-    REP_TYPE = AverageSubTomogram
-    """ Represent a Class that groups Volume objects.
-    Usually the representative of the class is another Volume.
+    """ Represent a Class that groups SubTomogram objects.
+    The representative of the class is an AverageSubTomogram.
     """
+    REP_TYPE = AverageSubTomogram
+
+    def copyInfo(self, other):
+        """ Copy basic information (id and other properties) but not
+        _mapperPath or _size from other set of SubTomograms to current one.
+        """
+        self.copy(other, copyId=False, ignoreAttrs=['_mapperPath', '_size'])
+
+    def clone(self):
+        clone = self.getClass()()
+        clone.copy(self, ignoreAttrs=['_mapperPath', '_size'])
+        return clone
+
     def close(self):
         # Do nothing on close, since the db will be closed by SetOfClasses
         pass

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -463,7 +463,7 @@ class SetOfCoordinates3D(data.EMSet):
         data.EMSet.__init__(self, **kwargs)
         self._volumesPointer = pwobj.Pointer()
         self._boxSize = pwobj.Integer()
-        self._samplingRate = pwobj.Integer()
+        self._samplingRate = pwobj.Float()
 
     def getBoxSize(self):
         """ Return the box size of the particles.

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -463,6 +463,7 @@ class SetOfCoordinates3D(data.EMSet):
         data.EMSet.__init__(self, **kwargs)
         self._volumesPointer = pwobj.Pointer()
         self._boxSize = pwobj.Integer()
+        self._samplingRate = pwobj.Integer()
 
     def getBoxSize(self):
         """ Return the box size of the particles.
@@ -472,6 +473,14 @@ class SetOfCoordinates3D(data.EMSet):
     def setBoxSize(self, boxSize):
         """ Set the box size of the particles. """
         self._boxSize.set(boxSize)
+
+    def getSamplingRate(self):
+       """ Return the sampling rate of the particles. """
+       return self._samplingRate.get()
+
+    def setSamplingRate(self, sampling):
+       """ Set the sampling rate of the particles. """
+       self._samplingRate.set(sampling)
 
     def iterVolumes(self):
         """ Iterate over the micrographs set associated with this

--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -5,9 +5,8 @@ Tomography = [
 	{"tag": "protocol", "value": "ProtImportTomograms",      "text": "default"},
 	{"tag": "protocol", "value": "ProtImportSubTomograms",      "text": "default"},
 	{"tag": "protocol", "value": "ProtImportCoordinates3D",      "text": "default"},
-	{"tag": "protocol", "value": "ProtImportVolumes",     "text": "import volumes"},
 	{"tag": "section", "text": "more", "openItem": "False", "children": [
-	{"tag": "protocol", "value": "ProtImportPdb",         "text": "import atom structure"},
+    {"tag": "protocol", "value": "ProtImportVolumes",     "text": "import volumes"},
 	{"tag": "protocol", "value": "ProtImportAverages",    "text": "import averages"},
 	{"tag": "protocol", "value": "ProtImportMask",        "text": "import masks"},
 	{"tag": "protocol", "value": "ProtEmxExport",         "text": "export to EMX"}

--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -5,12 +5,8 @@ Tomography = [
 	{"tag": "protocol", "value": "ProtImportTomograms",      "text": "default"},
 	{"tag": "protocol", "value": "ProtImportSubTomograms",      "text": "default"},
 	{"tag": "protocol", "value": "ProtImportCoordinates3D",      "text": "default"},
-	{"tag": "protocol", "value": "ProtImportMicrographs", "text": "import micrographs"},
-	{"tag": "protocol", "value": "ProtImportParticles",   "text": "import particles"},
 	{"tag": "protocol", "value": "ProtImportVolumes",     "text": "import volumes"},
 	{"tag": "section", "text": "more", "openItem": "False", "children": [
-	{"tag": "protocol", "value": "ProtImportCoordinates",   "text": "import coordinates"},
-	{"tag": "protocol", "value": "ProtImportCTF",   "text": "import ctfs"},
 	{"tag": "protocol", "value": "ProtImportPdb",         "text": "import atom structure"},
 	{"tag": "protocol", "value": "ProtImportAverages",    "text": "import averages"},
 	{"tag": "protocol", "value": "ProtImportMask",        "text": "import masks"},

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -40,13 +40,21 @@ from .move_to_plugins.protocol_ts_gctf import ProtTsGctf
 from .move_to_plugins.protocol_imod_auto3d import ProtImodAuto3D
 from .move_to_plugins.protocol_imod_etomo import ProtImodEtomo
 
+emprotocol = pyworkflow.em.protocol.EMProtocol
+setattr(emprotocol, "_createSetOfClassesSubTomograms", ProtTomoBase._createSetOfClassesSubTomograms.__func__)
+setattr(emprotocol, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomograms.__func__)
+setattr(emprotocol, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
+setattr(emprotocol, "_createSet", ProtTomoBase._createSet.__func__)
 
-protUserSubSet = pyworkflow.em.ProtUserSubSet
-setattr(protUserSubSet, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomograms.__func__)
-setattr(protUserSubSet, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
-setattr(protUserSubSet, "_createSet", ProtTomoBase._createSet.__func__)
 
-protUnionSet = pyworkflow.em.ProtUnionSet
-setattr(protUnionSet, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomograms.__func__)
-setattr(protUnionSet, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
-setattr(protUnionSet, "_createSet", ProtTomoBase._createSet.__func__)
+def scaleSplines(inputFn, outputFn, scaleFactor):
+    """ Scale an image using splines. """
+    import xmippLib
+    I = xmippLib.Image(inputFn)
+    x, y, z, _ = I.getDimensions()
+    I.scale(int(x * scaleFactor), int(y * scaleFactor),
+            int(z * scaleFactor))
+    I.write(outputFn)
+
+ih = pyworkflow.em.ImageHandler
+setattr(ih, "scaleSplines", staticmethod(scaleSplines))

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -40,13 +40,14 @@ from .move_to_plugins.protocol_ts_gctf import ProtTsGctf
 from .move_to_plugins.protocol_imod_auto3d import ProtImodAuto3D
 from .move_to_plugins.protocol_imod_etomo import ProtImodEtomo
 
+# This code extends EMProtocol allowing the use of Scipion protocols to create subsets for tomography objects
 emprotocol = pyworkflow.em.protocol.EMProtocol
 setattr(emprotocol, "_createSetOfClassesSubTomograms", ProtTomoBase._createSetOfClassesSubTomograms.__func__)
 setattr(emprotocol, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomograms.__func__)
 setattr(emprotocol, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
 setattr(emprotocol, "_createSet", ProtTomoBase._createSet.__func__)
 
-
+# This cosde extends ImageHandler allowing the use of scaling with splines untill this functionality is implemented in Scipion
 def scaleSplines(inputFn, outputFn, scaleFactor):
     """ Scale an image using splines. """
     import xmippLib

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -46,3 +46,7 @@ setattr(protUserSubSet, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSub
 setattr(protUserSubSet, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
 setattr(protUserSubSet, "_createSet", ProtTomoBase._createSet.__func__)
 
+protUnionSet = pyworkflow.em.ProtUnionSet
+setattr(protUnionSet, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomograms.__func__)
+setattr(protUnionSet, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
+setattr(protUnionSet, "_createSet", ProtTomoBase._createSet.__func__)

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -47,7 +47,9 @@ setattr(emprotocol, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomo
 setattr(emprotocol, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
 setattr(emprotocol, "_createSet", ProtTomoBase._createSet.__func__)
 
-# This cosde extends ImageHandler allowing the use of scaling with splines untill this functionality is implemented in Scipion
+
+# This code extends ImageHandler allowing the use of scaling with splines until this functionality is implemented
+# in Scipion
 def scaleSplines(inputFn, outputFn, scaleFactor):
     """ Scale an image using splines. """
     import xmippLib

--- a/tomo/protocols/protocol_import_coordinates.py
+++ b/tomo/protocols/protocol_import_coordinates.py
@@ -75,6 +75,7 @@ class ProtImportCoordinates3D(ProtTomoImportFiles):
         importTomogram = self.importTomogram.get()
         coordsSet = self._createSetOfCoordinates3D(importTomogram)
         coordsSet.setBoxSize(self.boxSize.get())
+        coordsSet.setSamplingRate(self.samplingRate.get())
         ci = self.getImportClass()
         for coordFile, fileId in self.iterFiles():
             if importTomogram is not None:

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -371,7 +371,7 @@ class TestTomoImportSetOfCoordinates3D(BaseTest):
                                  filesPath= self.coords3D,
                                  importTomogram=protImportTomogram.outputTomogram,
                                  filesPattern='', boxSize=32,
-                                 samplingRate=5)
+                                 samplingRate=5.5)
         self.launchProtocol(protImportCoordinates3d)
 
         return protImportCoordinates3d
@@ -383,8 +383,7 @@ class TestTomoImportSetOfCoordinates3D(BaseTest):
                              "There was a problem with coordinates 3d output")
         self.assertTrue(output.getSize() == 5)
         self.assertTrue(output.getBoxSize() == 32)
-
-
+        self.assertTrue(output.getSamplingRate() == 5.5)
         return output
 
 


### PR DESCRIPTION
-Attribute **samplingRate** added to object `SetOfCoordinates3D` with the corresponding get and set.
-In `protocol_import_coordinates` set samplingRate of object SetOfCoordinates3D

This changes are required for the correct working of `protocol_tomo_extraction` in `scipion-em-eman2` after PR scipion-em/scipion-em-eman2/pull/33

*Extra: **Remove non-tomography imports** from `protocols.conf` by user request (they have no sense in tomography menu of scipion and they are confusing for the user).