### PR TITLE
Small import changes

### DIFF
--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -466,8 +466,11 @@ class ProtImportTsBase(pwem.ProtImport, ProtTomoBase):
 
     def _getTiltAngleRange(self):
         """ Return the list with all expected tilt angles. """
+        offset = 1
+        if self.minAngle.get() > self.maxAngle.get():
+            offset = -1 * offset
         return np.arange(self.minAngle.get(),
-                         self.maxAngle.get() + 1,  # also include max angle
+                         self.maxAngle.get() + offset,  # also include last angle
                          self.stepAngle.get())
 
     def _getSortedAngles(self, tiltSeriesList):


### PR DESCRIPTION
These changes allow the imported from range angles to be in the opposite order so they fit the tilt series stack.