### PR TITLE
add ts protocols to protocols.conf

### DIFF
--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -1,22 +1,24 @@
 [PROTOCOLS]
 Tomography = [
 	{"tag": "section", "text": "Imports", "icon": "bookmark.png", "children": [
-	{"tag": "protocol", "value": "ProtImportTiltSeries",      "text": "default"},
-	{"tag": "protocol", "value": "ProtImportTomograms",      "text": "default"},
-	{"tag": "protocol", "value": "ProtImportSubTomograms",      "text": "default"},
-	{"tag": "protocol", "value": "ProtImportCoordinates3D",      "text": "default"},
-	{"tag": "section", "text": "more", "openItem": "False", "children": [
-    {"tag": "protocol", "value": "ProtImportVolumes",     "text": "import volumes"},
-	{"tag": "protocol", "value": "ProtImportAverages",    "text": "import averages"},
-	{"tag": "protocol", "value": "ProtImportMask",        "text": "import masks"},
-	{"tag": "protocol", "value": "ProtEmxExport",         "text": "export to EMX"}
-	]}
+        {"tag": "protocol", "value": "ProtImportTs",      "text": "default"},
+        {"tag": "protocol", "value": "ProtImportTsMovies",      "text": "default"},
+        {"tag": "protocol", "value": "ProtImportTomograms",      "text": "default"},
+        {"tag": "protocol", "value": "ProtImportSubTomograms",      "text": "default"},
+        {"tag": "protocol", "value": "ProtImportCoordinates3D",      "text": "default"},
+        {"tag": "section", "text": "more", "openItem": "False", "children": [
+            {"tag": "protocol", "value": "ProtImportVolumes",     "text": "import volumes"},
+            {"tag": "protocol", "value": "ProtImportAverages",    "text": "import averages"},
+            {"tag": "protocol", "value": "ProtImportMask",        "text": "import masks"},
+            {"tag": "protocol", "value": "ProtEmxExport",         "text": "export to EMX"}
+	    ]}
 	]},
 	{"tag": "section", "text": "Movies/Micrographs", "children": [
-	{"tag": "protocol", "value": "ProtTsCorrectMotion",      "text": "default"},
-	{"tag": "protocol", "value": "ProtTsEstimateCTF",      "text": "default"}
+	    {"tag": "protocol", "value": "ProtTsAverage",      "text": "default"}
 	]},
 	{"tag": "section", "text": "Reconstruction", "children": []},
+    {"tag": "section", "text": "Particles", "children": []},
+    {"tag": "section", "text": "Preprocessing", "children": []},
 	{"tag": "section", "text": "Subtomogram averaging", "children": []},
 	{"tag": "section", "text": "Postprocessing", "children": [
     {"tag": "protocol_group", "text": "Denoise", "openItem": "False", "children": []},

--- a/tomo/protocols/protocol_ts_correct_motion.py
+++ b/tomo/protocols/protocol_ts_correct_motion.py
@@ -248,7 +248,7 @@ class ProtTsAverage(ProtTsCorrectMotion):
     Simple protocol to average TiltSeries movies as basic
     motion correction. It is used mainly for testing purposes.
     """
-    _label = 'average tiltseries (testing)'
+    _label = 'average tiltseries'
 
     def _processTiltImageM(self, workingFolder, tiltImageM, *args):
         """ Simple add all frames and divide by its number. """


### PR DESCRIPTION
Fix protocols.conf to show correctly currents sections in Tomography menu of Scipion.
I have added to those sections the protocols regarding tilt series (import tilt series, import tilt series movies and average tilt series). Please @delarosatrevin check if they are located in the correct section and if I missed include any "user" protocol (**not** base protocols) in protocols.conf.