### PR TITLE
Import dynamo subtomos

### DIFF
--- a/tomo/tests/__init__.py
+++ b/tomo/tests/__init__.py
@@ -30,7 +30,7 @@ DataSet(name='tomo-em', folder='tomo-em',
         files={
                'tomo1': 'overview_wbp.em',
                'tomo2': 'overview_wbp2.em',
-               'tomo3': 'import_tomo_8_mn.mrc',
+               'tomo3': 'tomo_8_mn.mrc',
                'subtomo': 'basename.hdf',
                'eman_coordinates': 'coordinates3Deman2',
                'etomo': 'tutorialData',

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -308,6 +308,16 @@ class TestTomoImportSubTomograms(BaseTest):
         self.launchProtocol(protImport)
         return protImport
 
+     def _runImportDynSubTomograms(self):
+        protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
+                                      filesPath=self.path,
+                                      filesPattern='*.em',
+                                      samplingRate=1.35,
+                                      source=2,
+                                      table='/home/estrellafg/initial.tbl')  # TODO: change by testdata!
+        self.launchProtocol(protImport)
+        return protImport
+
      def test_import_sub_tomograms(self):
          protImport = self._runImportSubTomograms()
          output = getattr(protImport, 'outputSubTomograms', None)
@@ -341,6 +351,28 @@ class TestTomoImportSubTomograms(BaseTest):
                  self.assertTrue(subtomo.getCoordinate3D().getZ() == 256)
 
          return output2
+
+     def test_import_dynamo_subtomograms(self):
+         protImport = self._runImportDynSubTomograms()
+         output = getattr(protImport, 'outputSubTomograms', None)
+         self.assertTrue(output.getSamplingRate() == 1.35)
+         self.assertTrue(output.getFirstItem().getSamplingRate() == 1.35)
+         self.assertTrue(output.getDim()[0] == 1024)
+         self.assertTrue(output.getDim()[1] == 1024)
+         self.assertTrue(output.getDim()[2] == 512)
+         # Metada from dynamo table:
+         self.assertTrue(output.getFirstItem().getObjId() == 34)
+         self.assertTrue(output.getFirstItem().getClassId() == 1)
+         self.assertTrue(output.getFirstItem().getAcquisition().getAngleMin() == -60)
+         self.assertTrue(output.getFirstItem().getAcquisition().getAngleMax() == 60)
+         self.assertTrue(output.getFirstItem().getCoordinate3D.getX() == 129)
+         self.assertTrue(output.getFirstItem().getCoordinate3D.getY() == 156)
+         self.assertTrue(output.getFirstItem().getCoordinate3D.getZ() == 166)
+
+
+
+
+        # TODO: check if subtomos attributes are the same as in the table
 
 
 class TestTomoImportSetOfCoordinates3D(BaseTest):

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -371,11 +371,6 @@ class TestTomoImportSubTomograms(BaseTest):
          self.assertTrue(output.getFirstItem().getCoordinate3D.getZ() == 166)
 
 
-
-
-        # TODO: check if subtomos attributes are the same as in the table
-
-
 class TestTomoImportSetOfCoordinates3D(BaseTest):
     """This class check if the protocol to import set of coordinates 3d works properly."""
 

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -259,6 +259,7 @@ class TestTomoImportSubTomograms(BaseTest):
          cls.dataset = DataSet.getDataSet('tomo-em')
          cls.tomogram = cls.dataset.getFile('tomo1')
          cls.coords3D = cls.dataset.getFile('overview_wbp.txt')
+         cls.table = cls.dataset.getFile('initial.tbl')
          cls.path = cls.dataset.getPath()
 
      def _runImportSubTomograms(self):
@@ -314,7 +315,7 @@ class TestTomoImportSubTomograms(BaseTest):
                                       filesPattern='*.em',
                                       samplingRate=1.35,
                                       source=2,
-                                      table='/home/estrellafg/initial.tbl')  # TODO: change by testdata!
+                                      tablePath=self.table)
         self.launchProtocol(protImport)
         return protImport
 

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -271,15 +271,15 @@ class TestTomoImportSubTomograms(BaseTest):
 
         protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
                                  auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
-                                 filesPath= self.coords3D,
+                                 filesPath=self.coords3D,
                                  importTomograms=protImportTomogram.outputTomograms,
                                  filesPattern='', boxSize=32,
                                  samplingRate=5)
         self.launchProtocol(protImportCoordinates3d)
 
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
-                                      filesPath=self.tomogram,
-                                      filesPattern='',
+                                      filesPath=self.path,
+                                      filesPattern='*.hdf',
                                       samplingRate=1.35,
                                       importCoordinates=protImportCoordinates3d.outputCoordinates)
         self.launchProtocol(protImport)
@@ -295,7 +295,7 @@ class TestTomoImportSubTomograms(BaseTest):
 
         protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
                                  auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
-                                 filesPath= self.coords3D,
+                                 filesPath=self.coords3D,
                                  importTomograms=protImportTomogram.outputTomograms,
                                  filesPattern='', boxSize=32,
                                  samplingRate=5)
@@ -303,7 +303,7 @@ class TestTomoImportSubTomograms(BaseTest):
 
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
                                       filesPath=self.path,
-                                      filesPattern='*.em',
+                                      filesPattern='*.hdf',
                                       samplingRate=1.35,
                                       importCoordinates=protImportCoordinates3d.outputCoordinates)
         self.launchProtocol(protImport)
@@ -312,7 +312,7 @@ class TestTomoImportSubTomograms(BaseTest):
      def _runImportDynSubTomograms(self):
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
                                       filesPath=self.path,
-                                      filesPattern='*.em',
+                                      filesPattern='*.hdf',
                                       samplingRate=1.35,
                                       importFrom=2,
                                       tablePath=self.table)
@@ -324,9 +324,9 @@ class TestTomoImportSubTomograms(BaseTest):
          output = getattr(protImport, 'outputSubTomograms', None)
          self.assertTrue(output.getSamplingRate() == 1.35)
          self.assertTrue(output.getFirstItem().getSamplingRate() == 1.35)
-         self.assertTrue(output.getDim()[0] == 1024)
-         self.assertTrue(output.getDim()[1] == 1024)
-         self.assertTrue(output.getDim()[2] == 512)
+         self.assertTrue(output.getDim()[0] == 32)
+         self.assertTrue(output.getDim()[1] == 32)
+         self.assertTrue(output.getDim()[2] == 32)
          self.assertTrue(output.getFirstItem().getCoordinate3D().getX() == 314)
          self.assertTrue(output.getFirstItem().getCoordinate3D().getY() == 350)
          self.assertTrue(output.getFirstItem().getCoordinate3D().getZ() == 256)
@@ -338,9 +338,9 @@ class TestTomoImportSubTomograms(BaseTest):
          self.assertIsNotNone(output2,
                               "There was a problem with Import SubTomograms protocol")
          self.assertTrue(output2.getSamplingRate() == 1.35)
-         self.assertTrue(output2.getDim()[0] == 1024)
-         self.assertTrue(output2.getDim()[1] == 1024)
-         self.assertTrue(output2.getDim()[2] == 512)
+         self.assertTrue(output2.getDim()[0] == 32)
+         self.assertTrue(output2.getDim()[1] == 32)
+         self.assertTrue(output2.getDim()[2] == 32)
          for i, subtomo in enumerate(output2.iterItems()):
              if i == 1:
                  self.assertTrue(subtomo.getCoordinate3D().getX() == 174)
@@ -358,9 +358,9 @@ class TestTomoImportSubTomograms(BaseTest):
          output = getattr(protImport, 'outputSubTomograms', None)
          self.assertTrue(output.getSamplingRate() == 1.35)
          self.assertTrue(output.getFirstItem().getSamplingRate() == 1.35)
-         self.assertTrue(output.getDim()[0] == 1024)
-         self.assertTrue(output.getDim()[1] == 1024)
-         self.assertTrue(output.getDim()[2] == 512)
+         self.assertTrue(output.getDim()[0] == 32)
+         self.assertTrue(output.getDim()[1] == 32)
+         self.assertTrue(output.getDim()[2] == 32)
          # Metada from dynamo table:
          self.assertTrue(output.getFirstItem().getObjId() == 4)
          self.assertTrue(output.getFirstItem().getClassId() == 1)

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -362,13 +362,13 @@ class TestTomoImportSubTomograms(BaseTest):
          self.assertTrue(output.getDim()[1] == 1024)
          self.assertTrue(output.getDim()[2] == 512)
          # Metada from dynamo table:
-         self.assertTrue(output.getFirstItem().getObjId() == 34)
+         self.assertTrue(output.getFirstItem().getObjId() == 4)
          self.assertTrue(output.getFirstItem().getClassId() == 1)
          self.assertTrue(output.getFirstItem().getAcquisition().getAngleMin() == -60)
          self.assertTrue(output.getFirstItem().getAcquisition().getAngleMax() == 60)
-         self.assertTrue(output.getFirstItem().getCoordinate3D.getX() == 129)
-         self.assertTrue(output.getFirstItem().getCoordinate3D.getY() == 156)
-         self.assertTrue(output.getFirstItem().getCoordinate3D.getZ() == 166)
+         self.assertTrue(output.getFirstItem().getCoordinate3D().getX() == 175)
+         self.assertTrue(output.getFirstItem().getCoordinate3D().getY() == 134)
+         self.assertTrue(output.getFirstItem().getCoordinate3D().getZ() == 115)
 
 
 class TestTomoImportSetOfCoordinates3D(BaseTest):


### PR DESCRIPTION
Now it is possible to import subtomograms from dynamo (importing the metadata from dynamo tables).
To use this new feature it is necessary to have installed the dynamo plugin (https://github.com/scipion-em/scipion-em-dynamo) in branch https://github.com/scipion-em/scipion-em-dynamo/pull/3 (in PR now).
However, the basic import should be work without dynamo.