### PR TITLE
Error showing when opening Tomograms with no meshes in viewer fixed

### DIFF
--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -44,7 +44,7 @@ setattr(emprotocol, "_createSetOfClassesSubTomograms", ProtTomoBase._createSetOf
 setattr(emprotocol, "_createSetOfSubTomograms", ProtTomoBase._createSetOfSubTomograms.__func__)
 setattr(emprotocol, "_createSetOfTomograms", ProtTomoBase._createSetOfTomograms.__func__)
 setattr(emprotocol, "_createSet", ProtTomoBase._createSet.__func__)
-
+setattr(emprotocol, "_createSetOfMeshes", ProtTomoBase._createSetOfMeshes.__func__)
 
 # This code extends ImageHandler allowing the use of scaling with splines until this functionality is implemented
 # in Scipion

--- a/tomo/viewers/views_tkinter_tree.py
+++ b/tomo/viewers/views_tkinter_tree.py
@@ -322,7 +322,9 @@ class TomogramsDialog(ToolbarListDialog):
 
         macro = r"""path = "%s";
     file = "%s"
+    if (File.exists(path + file + ".zip")){
     roiManager("Open", path + file + ".zip");
+    }
     """ % (os.path.join(path, ''), os.path.splitext(tomogramName)[0])
         macroFid = open(macroPath, 'w')
         macroFid.write(macro)


### PR DESCRIPTION
Small fix to solve the error showing when Tomograms with no `SetOfMeshes` associated were opened with ImageJ.