### PR TITLE
fix dims

### DIFF
--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -53,8 +53,7 @@ def scaleSplines(inputFn, outputFn, scaleFactor):
     import xmippLib
     I = xmippLib.Image(inputFn)
     x, y, z, _ = I.getDimensions()
-    I.scale(int(x * scaleFactor), int(y * scaleFactor),
-            int(z * scaleFactor))
+    I.scale(int(x/scaleFactor), int(y/scaleFactor), int(z/scaleFactor))
     I.write(outputFn)
 
 ih = pyworkflow.em.ImageHandler


### PR DESCRIPTION
This changes makes downsampling more intuitive. 
This method is only used (for the moment) in downsampling subtomograms option when extracting with Eman. Now, if the user wants to downsample subtomograms by 2, the factor to introduce is 2 instead of 0.5. 