### PR TITLE
remove coordinates in import subtomograms

### DIFF
--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -70,12 +70,12 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
                       help='Select dynamo table (.tbl) to link dynamo metadata to the subtomograms that will be '
                            'imported to Scipion. ')
 
-        form.addParam('importCoordinates', PointerParam,
-                      pointerClass='SetOfCoordinates3D',
-                      allowsNull=True,
-                      label='Input coordinates 3D',
-                      help='Select the coordinates for which the '
-                            'subtomograms were extracted.')
+        # form.addParam('importCoordinates', PointerParam,
+        #               pointerClass='SetOfCoordinates3D',
+        #               allowsNull=True,
+        #               label='Input coordinates 3D',
+        #               help='Select the coordinates for which the '
+        #                     'subtomograms were extracted.')
 
         ProtTomoImportAcquisition._defineParams(self, form)
 
@@ -109,11 +109,11 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
 
         self._openMetadataFile()  # Open the metadata file associated to the software used
 
-        if self.importCoordinates.get():
-            self.coords = []
-            for coord3D in self.importCoordinates.get().iterCoordinates():
-                self.coords.append(coord3D.clone())
-            self.subtomoSet.setCoordinates3D(self.importCoordinates)
+        # if self.importCoordinates.get():
+        #     self.coords = []
+        #     for coord3D in self.importCoordinates.get().iterCoordinates():
+        #         self.coords.append(coord3D.clone())
+        #     self.subtomoSet.setCoordinates3D(self.importCoordinates)
 
         self._parseAcquisitionData()
         for fileName, fileId in self.iterFiles():
@@ -159,7 +159,7 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
             subtomo.setLocation(index, newFileName)
 
         subtomo.setAcquisition(self._extractAcquisitionParameters(fileName))
-        self._setCoordinates3D(subtomo)
+        # self._setCoordinates3D(subtomo)
 
         self._importMetadata(subtomo)  # Select the import function from the software used
 
@@ -191,12 +191,12 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
         self._defineOutputs(outputSubTomograms=self.subtomoSet)
 
     # --------------------------- INFO functions ------------------------------
-    def _setCoordinates3D(self, subtomo):
-        if self.importCoordinates.get():
-            if len(self.coords) < 1:
-                raise Exception("Coordinates 3D and subtomograms should have the same size")
-            else:
-                subtomo.setCoordinate3D(self.coords.pop(0))
+    # def _setCoordinates3D(self, subtomo):
+    #     if self.importCoordinates.get():
+    #         if len(self.coords) < 1:
+    #             raise Exception("Coordinates 3D and subtomograms should have the same size")
+    #         else:
+    #             subtomo.setCoordinate3D(self.coords.pop(0))
 
     def _hasOutput(self):
         return self.hasAttribute('outputSubTomograms')

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -549,54 +549,54 @@ class TestTomoImportSubTomograms(BaseTest):
     def setUpClass(cls):
          setupTestProject(cls)
          cls.dataset = DataSet.getDataSet('tomo-em')
-         cls.tomogram = cls.dataset.getFile('tomo1')
-         cls.coords3D = cls.dataset.getFile('overview_wbp.txt')
+         # cls.tomogram = cls.dataset.getFile('tomo1')
+         # cls.coords3D = cls.dataset.getFile('overview_wbp.txt')
          cls.table = cls.dataset.getFile('initial.tbl')
          cls.path = cls.dataset.getPath()
          cls.subtomos = cls.dataset.getFile('basename.hdf')
 
     def _runImportSubTomograms(self):
 
-        protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
-                                              filesPath=self.tomogram,
-                                              samplingRate=5)
-        self.launchProtocol(protImportTomogram)
-
-        protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
-                                 auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
-                                 filesPath=self.coords3D,
-                                 importTomograms=protImportTomogram.outputTomograms,
-                                 filesPattern='', boxSize=32,
-                                 samplingRate=5)
-        self.launchProtocol(protImportCoordinates3d)
+        # protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
+        #                                       filesPath=self.tomogram,
+        #                                       samplingRate=5)
+        # self.launchProtocol(protImportTomogram)
+        #
+        # protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
+        #                          auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
+        #                          filesPath=self.coords3D,
+        #                          importTomograms=protImportTomogram.outputTomograms,
+        #                          filesPattern='', boxSize=32,
+        #                          samplingRate=5)
+        # self.launchProtocol(protImportCoordinates3d)
 
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
                                       filesPath=self.subtomos,
-                                      samplingRate=1.35,
-                                      importCoordinates=protImportCoordinates3d.outputCoordinates)
+                                      samplingRate=1.35)
+                                      # importCoordinates=protImportCoordinates3d.outputCoordinates)
         self.launchProtocol(protImport)
         return protImport
 
     def _runImportSubTomograms2(self):
 
-        protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
-                                              filesPath=self.tomogram,
-                                              filesPattern='',
-                                              samplingRate=5)
-        self.launchProtocol(protImportTomogram)
-
-        protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
-                                 auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
-                                 filesPath=self.coords3D,
-                                 importTomograms=protImportTomogram.outputTomograms,
-                                 filesPattern='', boxSize=32,
-                                 samplingRate=5)
-        self.launchProtocol(protImportCoordinates3d)
+        # protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
+        #                                       filesPath=self.tomogram,
+        #                                       filesPattern='',
+        #                                       samplingRate=5)
+        # self.launchProtocol(protImportTomogram)
+        #
+        # protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
+        #                          auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
+        #                          filesPath=self.coords3D,
+        #                          importTomograms=protImportTomogram.outputTomograms,
+        #                          filesPattern='', boxSize=32,
+        #                          samplingRate=5)
+        # self.launchProtocol(protImportCoordinates3d)
 
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
                                       filesPath=self.subtomos,
-                                      samplingRate=1.35,
-                                      importCoordinates=protImportCoordinates3d.outputCoordinates)
+                                      samplingRate=1.35)
+                                      # importCoordinates=protImportCoordinates3d.outputCoordinates)
         self.launchProtocol(protImport)
         return protImport
 
@@ -617,9 +617,9 @@ class TestTomoImportSubTomograms(BaseTest):
          self.assertTrue(output.getDim()[0] == 32)
          self.assertTrue(output.getDim()[1] == 32)
          self.assertTrue(output.getDim()[2] == 32)
-         self.assertTrue(output.getFirstItem().getCoordinate3D().getX() == 314)
-         self.assertTrue(output.getFirstItem().getCoordinate3D().getY() == 350)
-         self.assertTrue(output.getFirstItem().getCoordinate3D().getZ() == 256)
+         # self.assertTrue(output.getFirstItem().getCoordinate3D().getX() == 314)
+         # self.assertTrue(output.getFirstItem().getCoordinate3D().getY() == 350)
+         # self.assertTrue(output.getFirstItem().getCoordinate3D().getZ() == 256)
          self.assertIsNotNone(output,
                              "There was a problem with Import SubTomograms protocol")
 
@@ -631,15 +631,15 @@ class TestTomoImportSubTomograms(BaseTest):
          self.assertTrue(output2.getDim()[0] == 32)
          self.assertTrue(output2.getDim()[1] == 32)
          self.assertTrue(output2.getDim()[2] == 32)
-         for i, subtomo in enumerate(output2.iterItems()):
-             if i == 1:
-                 self.assertTrue(subtomo.getCoordinate3D().getX() == 174)
-                 self.assertTrue(subtomo.getCoordinate3D().getY() == 172)
-                 self.assertTrue(subtomo.getCoordinate3D().getZ() == 256)
-             if i == 0:
-                 self.assertTrue(subtomo.getCoordinate3D().getX() == 314)
-                 self.assertTrue(subtomo.getCoordinate3D().getY() == 350)
-                 self.assertTrue(subtomo.getCoordinate3D().getZ() == 256)
+         # for i, subtomo in enumerate(output2.iterItems()):
+         #     if i == 1:
+         #         self.assertTrue(subtomo.getCoordinate3D().getX() == 174)
+         #         self.assertTrue(subtomo.getCoordinate3D().getY() == 172)
+         #         self.assertTrue(subtomo.getCoordinate3D().getZ() == 256)
+         #     if i == 0:
+         #         self.assertTrue(subtomo.getCoordinate3D().getX() == 314)
+         #         self.assertTrue(subtomo.getCoordinate3D().getY() == 350)
+         #         self.assertTrue(subtomo.getCoordinate3D().getZ() == 256)
 
          return output2
 


### PR DESCRIPTION
`Input coordinates `functionality commented in` input subtomograms protocol`, as it is not working properly for the moment. It was assigning a coordinate to a subtomogram in consecutive order without ensuring that the coordinate really belong to that subtomogram. 
In the case of importing subtomograms from Dynamo, this functionality has no sense anyway because coordinate information of the subtomogram is already contained in the Dynamo table (metadata).
The code is commented instead of removed to keep it for a future fix of this functionality.