### PR TITLE
Extract coordinates for tomo

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -616,6 +616,12 @@ class Coordinate3D(data.EMObject):
         self.setObjId(coord.getObjId())
         self.setBoxSize(coord.getBoxSize())
 
+    def setBoxSize(self, boxSize):
+        self._boxSize = boxSize
+    
+    def getBoxSize(self):
+        return self._boxSize
+
     def getVolId(self):
         return self._volId.get()
 

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -618,7 +618,7 @@ class Coordinate3D(data.EMObject):
 
     def setBoxSize(self, boxSize):
         self._boxSize = boxSize
-    
+
     def getBoxSize(self):
         return self._boxSize
 

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -618,7 +618,7 @@ class Coordinate3D(data.EMObject):
 
     def setBoxSize(self, boxSize):
         self._boxSize = boxSize
-
+    
     def getBoxSize(self):
         return self._boxSize
 

--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -17,7 +17,11 @@ Tomography = [
 	    {"tag": "protocol", "value": "ProtTsAverage",      "text": "default"}
 	]},
 	{"tag": "section", "text": "Reconstruction", "children": []},
-	{"tag": "section", "text": "Particles", "children": []},
+	{"tag": "section", "text": "Particles", "children": [
+	    {"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
+            {"tag": "protocol", "value": "ProtTomoExtractCoords",   "text": "default"}
+        ]}
+	]},
 	{"tag": "section", "text": "Preprocessing", "children": []},
 	{"tag": "section", "text": "Subtomogram averaging", "children": []},
 	{"tag": "section", "text": "Postprocessing", "children": [

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -35,3 +35,4 @@ from .protocol_import_tomograms import ProtImportTomograms
 from .protocol_import_subtomograms import ProtImportSubTomograms
 from .protocol_import_coordinates import ProtImportCoordinates3D
 from .protocol_alignment_assign_subtomo import ProtAlignmentAssignSubtomo
+from .protocol_extract_coordinates import ProtTomoExtractCoords

--- a/tomo/protocols/protocol_extract_coordinates.py
+++ b/tomo/protocols/protocol_extract_coordinates.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+# **************************************************************************
+# *
+# * Authors:     David Herreros Calero (dherreros@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import pyworkflow.protocol.params as params
+
+from .protocol_base import ProtTomoPicking
+
+from ..objects import Coordinate3D
+
+
+class ProtTomoExtractCoords(ProtTomoPicking):
+    """
+    Extract the coordinates information from a set of subtomograms.
+
+    This protocol is useful when we want to re-extract the subtomograms
+    (maybe resulting from classification) with the
+    original dimensions. It can be also handy to visualize the resulting
+    subtomograms in their location on the tomograms.
+    """
+
+    _label = 'extract 3D coordinates'
+
+    # --------------------------- DEFINE param functions ----------------------
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+
+        form.addParam('inputSubTomos', params.PointerParam,
+                      pointerClass='SetOfSubTomograms',
+                      label='Input Subtomograms', important=True,
+                      help='Select the subtomograms from which you want\n'
+                           'to extract the coordinates.')
+
+        form.addParam('inputTomos', params.PointerParam,
+                      pointerClass='SetOfTomograms',
+                      label='Input Tomograms', important=True,
+                      help='Select the tomograms to which you want to\n'
+                           'associate the coordinates from the subtomograms.')
+
+        form.addParallelSection(threads=0, mpi=0)
+
+    # --------------------------- INSERT steps functions ----------------------
+    def _insertAllSteps(self):
+        self._insertFunctionStep('extractCoordinatesStep')
+        self._insertFunctionStep('createOutputStep')
+
+    def extractCoordinatesStep(self):
+        inTomos = self.getInputTomos()
+        inSubTomos = self.getInputSubTomos()
+        scale = inSubTomos.getSamplingRate() / inTomos.getSamplingRate()
+        print("Scaling coordinates by a factor *%0.2f*" % scale)
+
+        suffix = ''
+        self.outputCoords = self._createSetOfCoordinates3D(inTomos, suffix=suffix)
+
+        def appendCoordFromSubTomo(subTomo, boxSize):
+            coord = subTomo.getCoordinate3D()
+            tomoKey = coord.getVolId()
+            # import time
+            # time.sleep(10)
+            tomo = inTomos[tomoKey]
+
+            if tomo is None:
+                print("Skipping subtomogram, key %s not found" % tomoKey)
+            else:
+                newCoord.copyObjId(subTomo)
+                x, y, z = coord.getPosition()
+                newCoord.setPosition(x * scale, y * scale, z * scale)
+
+                newCoord.setVolume(tomo)
+                newCoord.setBoxSize(boxSize)
+                newCoord.setMatrix(coord.getMatrix())
+                self.outputCoords.append(newCoord)
+
+        newCoord = Coordinate3D()
+        boxSize = inSubTomos.getXDim() * scale
+        for subTomo in inSubTomos:
+            appendCoordFromSubTomo(subTomo, boxSize)
+
+        self.outputCoords.setBoxSize(boxSize)
+
+    def createOutputStep(self):
+        self._defineOutputs(outputCoordinates=self.outputCoords)
+        self._defineSourceRelation(self.inputSubTomos, self.outputCoords)
+        self._defineSourceRelation(self.inputTomos, self.outputCoords)
+
+    # ------------- UTILS functions ----------------
+    def getSuffix(self, suffix):
+        return "_tmp%s" % suffix
+
+    def getTmpOutputPath(self, suffix):
+        return self._getPath("coordinates%s.sqlite" % self.getSuffix(suffix))
+
+    def getInputTomos(self):
+        return self.inputTomos.get()
+
+    def getInputSubTomos(self):
+        return self.inputSubTomos.get()
+
+    # --------------------------- INFO functions ------------------------------
+    def _summary(self):
+        summary = []
+        ps1 = self.getInputSubTomos().getSamplingRate()
+        ps2 = self.getInputTomos().getSamplingRate()
+        summary.append(u'Input subtomograms pixel size: *%0.3f* (Å/px)' % ps1)
+        summary.append(u'Input tomograms pixel size: *%0.3f* (Å/px)' % ps2)
+        summary.append('Scaling coordinates by a factor of *%0.3f*' % (ps1 / ps2))
+
+        if hasattr(self, 'outputCoordinates'):
+            summary.append('Output coordinates: *%d*'
+                           % self.outputCoordinates.getSize())
+
+        return summary
+
+    def _methods(self):
+        # No much to add to summary information
+        return self._summary()
+
+    def _validate(self):
+        """ The function of this hook is to add some validation before the
+        protocol is launched to be executed. It should return a list of errors.
+        If the list is empty the protocol can be executed.
+        """
+        errors = []
+        inputSubTomos = self.getInputSubTomos()
+        first = inputSubTomos.getFirstItem()
+        if first.getCoordinate3D() is None:
+            errors.append('The input particles do not have coordinates!!!')
+
+        return errors

--- a/tomo/protocols/protocol_extract_coordinates.py
+++ b/tomo/protocols/protocol_extract_coordinates.py
@@ -48,17 +48,17 @@ class ProtTomoExtractCoords(ProtTomoPicking):
     def _defineParams(self, form):
         form.addSection(label='Input')
 
-        form.addParam('SubTomograms', params.PointerParam,
+        form.addParam('inputSubTomos', params.PointerParam,
                       pointerClass='SetOfSubTomograms',
-                      label='Input Subtomograms', important=True,
+                      label='Subtomograms', important=True,
                       help='Select the subtomograms from which you want\n'
                            'to extract the coordinates. The coordinate belonging to '
                            'each subtomogram should be already associated to an initial '
                            'tomogram.')
 
-        form.addParam('Tomograms', params.PointerParam,
+        form.addParam('inputTomos', params.PointerParam,
                       pointerClass='SetOfTomograms',
-                      label='Input Tomograms', important=True,
+                      label='Tomograms', important=True,
                       help='Select the tomograms to which you want to\n'
                            'associate the coordinates from the subtomograms.')
 
@@ -114,8 +114,8 @@ class ProtTomoExtractCoords(ProtTomoPicking):
 
     def createOutputStep(self):
         self._defineOutputs(outputCoordinates3D=self.outputCoords)
-        self._defineSourceRelation(self.SubTomograms, self.outputCoords)
-        self._defineSourceRelation(self.Tomograms, self.outputCoords)
+        self._defineSourceRelation(self.inputSubTomos, self.outputCoords)
+        self._defineSourceRelation(self.inputTomos, self.outputCoords)
 
     # ------------- UTILS functions ----------------
     def getSuffix(self, suffix):
@@ -125,10 +125,10 @@ class ProtTomoExtractCoords(ProtTomoPicking):
         return self._getPath("coordinates%s.sqlite" % self.getSuffix(suffix))
 
     def getInputTomos(self):
-        return self.Tomograms.get()
+        return self.inputTomos.get()
 
     def getInputSubTomos(self):
-        return self.SubTomograms.get()
+        return self.inputSubTomos.get()
 
     # --------------------------- INFO functions ------------------------------
     def _summary(self):

--- a/tomo/protocols/protocol_extract_coordinates.py
+++ b/tomo/protocols/protocol_extract_coordinates.py
@@ -75,6 +75,7 @@ class ProtTomoExtractCoords(ProtTomoPicking):
 
         suffix = ''
         self.outputCoords = self._createSetOfCoordinates3D(inTomos, suffix=suffix)
+        self.outputCoords.setSamplingRate(inTomos.getSamplingRate())
 
         def appendCoordFromSubTomo(subTomo, boxSize):
             coord = subTomo.getCoordinate3D()
@@ -101,7 +102,7 @@ class ProtTomoExtractCoords(ProtTomoPicking):
         self.outputCoords.setBoxSize(boxSize)
 
     def createOutputStep(self):
-        self._defineOutputs(outputCoordinates=self.outputCoords)
+        self._defineOutputs(outputCoordinates3D=self.outputCoords)
         self._defineSourceRelation(self.inputSubTomos, self.outputCoords)
         self._defineSourceRelation(self.inputTomos, self.outputCoords)
 

--- a/tomo/protocols/protocol_extract_coordinates.py
+++ b/tomo/protocols/protocol_extract_coordinates.py
@@ -79,8 +79,6 @@ class ProtTomoExtractCoords(ProtTomoPicking):
         def appendCoordFromSubTomo(subTomo, boxSize):
             coord = subTomo.getCoordinate3D()
             tomoKey = coord.getVolId()
-            # import time
-            # time.sleep(10)
             tomo = inTomos[tomoKey]
 
             if tomo is None:

--- a/tomo/protocols/protocol_extract_coordinates.py
+++ b/tomo/protocols/protocol_extract_coordinates.py
@@ -135,13 +135,11 @@ class ProtTomoExtractCoords(ProtTomoPicking):
         return summary
 
     def _methods(self):
-        # No much to add to summary information
         return self._summary()
 
     def _validate(self):
         """ The function of this hook is to add some validation before the
         protocol is launched to be executed. It should return a list of errors.
-        If the list is empty the protocol can be executed.
         """
         errors = []
         inputSubTomos = self.getInputSubTomos()

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -1031,8 +1031,8 @@ class TestTomoExtractCoordinates(BaseTest):
         self.launchProtocol(protImport)
 
         protExtract = self.newProtocol(tomo.protocols.ProtTomoExtractCoords,
-                                       inputSubTomos=protImport.outputSubTomograms,
-                                       inputTomos=protImportTomogram2.outputTomograms)
+                                       SubTomograms=protImport.outputSubTomograms,
+                                       Tomograms=protImportTomogram2.outputTomograms)
         self.launchProtocol(protExtract)
 
         return protExtract

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -992,59 +992,5 @@ class TestTomoAssignAlignment(BaseTest):
         return assign
 
 
-class TestTomoExtractCoordinates(BaseTest):
-    '''This class checks if the protocol extract coordinates from subtomograms works properly'''
-
-    @classmethod
-    def setUpClass(cls):
-        setupTestProject(cls)
-        cls.dataset = DataSet.getDataSet('tomo-em')
-        cls.tomogram1 = cls.dataset.getFile('tomo1')
-        cls.tomogram2 = cls.dataset.getFile('tomo2')
-        cls.coords3D = cls.dataset.getFile('overview_wbp.txt')
-        cls.subtomos = cls.dataset.getFile('basename.hdf')
-        cls.path = cls.dataset.getPath()
-
-    def _runExtractCoordinates(self):
-        protImportTomogram1 = self.newProtocol(tomo.protocols.ProtImportTomograms,
-                                              filesPath=self.tomogram1,
-                                              samplingRate=5)
-        self.launchProtocol(protImportTomogram1)
-
-        protImportTomogram2 = self.newProtocol(tomo.protocols.ProtImportTomograms,
-                                              filesPath=self.tomogram2,
-                                              samplingRate=5)
-        self.launchProtocol(protImportTomogram2)
-
-        protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
-                                                   auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_EMAN,
-                                                   filesPath=self.coords3D,
-                                                   importTomograms=protImportTomogram1.outputTomograms,
-                                                   filesPattern='', boxSize=32,
-                                                   samplingRate=5)
-        self.launchProtocol(protImportCoordinates3d)
-
-        protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
-                                      filesPath=self.subtomos,
-                                      samplingRate=1.35,
-                                      importCoordinates=protImportCoordinates3d.outputCoordinates)
-        self.launchProtocol(protImport)
-
-        protExtract = self.newProtocol(tomo.protocols.ProtTomoExtractCoords,
-                                       SubTomograms=protImport.outputSubTomograms,
-                                       Tomograms=protImportTomogram2.outputTomograms)
-        self.launchProtocol(protExtract)
-
-        return protExtract
-
-    def test_extractCoordinates(self):
-        coords = self._runExtractCoordinates()
-        self.assertTrue(getattr(coords, 'outputCoordinates3D'))
-        self.assertTrue(coords.outputCoordinates3D.getSamplingRate(), 5.0)
-        self.assertTrue(coords.outputCoordinates3D.getBoxSize(), 8)
-        self.assertTrue(coords.outputCoordinates3D.getSize(), 4)
-        return coords
-
-
 if __name__ == 'main':
     pass


### PR DESCRIPTION
`protocol_extract_coordinates` added to Tomo plugin. It extracts the coordinates associated to a `SetOfSubTomograms` and outputs them after being linked them to a new `SetOfTomograms`.