### PR TITLE
Assign tomos2subtomos

### DIFF
--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -22,7 +22,9 @@ Tomography = [
             {"tag": "protocol", "value": "ProtTomoExtractCoords",   "text": "default"}
         ]}
 	]},
-	{"tag": "section", "text": "Preprocessing", "children": []},
+	{"tag": "section", "text": "Preprocessing", "children": [
+	    {"tag": "protocol", "value": "ProtAssignTomo2Subtomo",   "text": "default"}
+	]},
 	{"tag": "section", "text": "Subtomogram averaging", "children": []},
 	{"tag": "section", "text": "Postprocessing", "children": [
             {"tag": "protocol", "value": "ProtAlignmentAssignSubtomo",      "text": "default"},

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -36,3 +36,4 @@ from .protocol_import_subtomograms import ProtImportSubTomograms
 from .protocol_import_coordinates import ProtImportCoordinates3D
 from .protocol_alignment_assign_subtomo import ProtAlignmentAssignSubtomo
 from .protocol_extract_coordinates import ProtTomoExtractCoords
+from .protocol_assign_tomo2subtomo import ProtAssignTomo2Subtomo

--- a/tomo/protocols/protocol_assign_tomo2subtomo.py
+++ b/tomo/protocols/protocol_assign_tomo2subtomo.py
@@ -49,7 +49,6 @@ class ProtAssignTomo2Subtomo(EMProtocol):
     # --------------------------- STEPS functions --------------------------------------------
     def createOutputStep(self):
         inputSubtomos = self.inputSubtomos.get()
-        inputTomos = self.inputTomos.get()
         outputSubtomos = inputSubtomos.create(self._getPath())
         outputSubtomos.copyInfo(inputSubtomos)
         outputSubtomos.copyItems(inputSubtomos, updateItemCallback=self._updateItem)
@@ -61,12 +60,8 @@ class ProtAssignTomo2Subtomo(EMProtocol):
     def _updateItem(self, item, row):
         inputTomos = self.inputTomos.get()
         for tomo in inputTomos:
-            # get just the filename but not the path
             tomoName = removeExt(tomo.getBaseName())
-            print("-------tomoName-----", tomoName)
-            print("-------SubtomoName-----", item.getFileName())
             if tomoName in item.getFileName():
-                print("-------ifTrue-----")
                 item.setVolName(tomoName)
                 item.setVolId(tomo.getObjId())
 

--- a/tomo/protocols/protocol_assign_tomo2subtomo.py
+++ b/tomo/protocols/protocol_assign_tomo2subtomo.py
@@ -48,6 +48,10 @@ class ProtAssignTomo2Subtomo(EMProtocol):
 
     # --------------------------- STEPS functions --------------------------------------------
     def createOutputStep(self):
+        self.tomoDict = {}
+        inputTomos = self.inputTomos.get()
+        for tomo in inputTomos:
+            self.tomoDict[tomo.getBaseName()] = tomo.getObjId()
         inputSubtomos = self.inputSubtomos.get()
         outputSubtomos = inputSubtomos.create(self._getPath())
         outputSubtomos.copyInfo(inputSubtomos)
@@ -58,12 +62,11 @@ class ProtAssignTomo2Subtomo(EMProtocol):
 
     # --------------------------- UTILS functions --------------------------------------------
     def _updateItem(self, item, row):
-        inputTomos = self.inputTomos.get()
-        for tomo in inputTomos:
-            tomoName = removeExt(tomo.getBaseName())
-            if tomoName in item.getFileName():
+        for tomoName in self.tomoDict:
+            if removeExt(tomoName) in item.getFileName():
                 item.setVolName(tomoName)
-                item.setVolId(tomo.getObjId())
+                item.setVolId(self.tomoDict.get(tomoName))
+                break
 
     # --------------------------- INFO functions --------------------------------------------
     def _summary(self):

--- a/tomo/protocols/protocol_assign_tomo2subtomo.py
+++ b/tomo/protocols/protocol_assign_tomo2subtomo.py
@@ -1,0 +1,91 @@
+# **************************************************************************
+# *
+# * Authors:     Estrella Fernandez Gimenez (me.fernandez@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.protocol.params import PointerParam
+from pyworkflow.utils import removeExt
+from pwem.protocols import EMProtocol
+
+class ProtAssignTomo2Subtomo(EMProtocol):
+    """ This protocol assign tomograms to subtomograms that have been imported before without tomograms.
+    Subtomograms should contain the name of the original tomogram in their own file name.
+    """
+    _label = 'assign tomos to subtomos'
+
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputSubtomos', PointerParam, pointerClass='SetOfSubTomograms', label='Subtomograms',
+                      help='Select the subtomograms that you want to update with original tomograms as precedents.'
+                           'The subtomograms should contain the original tomogram name in their own filename.')
+        form.addParam('inputTomos', PointerParam, pointerClass='SetOfTomograms', label='Tomograms',
+                      help='Select the tomograms to be assigned to the subtomograms.')
+
+    # --------------------------- INSERT steps functions --------------------------
+    def _insertAllSteps(self):
+        self._insertFunctionStep('createOutputStep')
+
+    # --------------------------- STEPS functions --------------------------------------------
+    def createOutputStep(self):
+        inputSubtomos = self.inputSubtomos.get()
+        inputTomos = self.inputTomos.get()
+        outputSubtomos = inputSubtomos.create(self._getPath())
+        outputSubtomos.copyInfo(inputSubtomos)
+        outputSubtomos.copyItems(inputSubtomos, updateItemCallback=self._updateItem)
+        self._defineOutputs(outputSubtomograms=outputSubtomos)
+        self._defineSourceRelation(self.inputSubtomos, outputSubtomos)
+        self._defineSourceRelation(self.inputTomos, outputSubtomos)
+
+    # --------------------------- UTILS functions --------------------------------------------
+    def _updateItem(self, item, row):
+        inputTomos = self.inputTomos.get()
+        for tomo in inputTomos:
+            # get just the filename but not the path
+            tomoName = removeExt(tomo.getBaseName())
+            print("-------tomoName-----", tomoName)
+            print("-------SubtomoName-----", item.getFileName())
+            if tomoName in item.getFileName():
+                print("-------ifTrue-----")
+                item.setVolName(tomoName)
+                item.setVolId(tomo.getObjId())
+
+    # --------------------------- INFO functions --------------------------------------------
+    def _summary(self):
+        summary = []
+        if not hasattr(self, 'outputSubtomograms'):
+            summary.append("Output subtomograms not ready yet.")
+        else:
+            summary.append("%s tomograms assigned to %s subtomograms." %
+                           (self.getObjectTag('inputTomos'), self.getObjectTag('inputSubtomos')))
+        return summary
+
+    def _methods(self):
+        methods = []
+        if not hasattr(self, 'outputSubtomograms'):
+            methods.append("Output subtomograms not ready yet.")
+        else:
+            methods.append("%d %s tomograms assigned to %d %s subtomograms." %
+                           (self.inputTomos.get().getSize(), self.getObjectTag('inputTomos'),
+                            self.inputSubtomos.get().getSize(), self.getObjectTag('inputSubtomos')))
+        return methods


### PR DESCRIPTION
New protocol to assign a set of tomograms to a set of subtomograms that have been imported to Scipion before without being related with any tomograms.
Subtomograms should contain in their own filename the name of the original tomogram from wich the subtomogram was extracted.