### PR TITLE
move dynamo import to its plugin

### DIFF
--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -31,10 +31,7 @@ from os.path import abspath, basename
 
 from pwem.emlib.image import ImageHandler
 from pwem.objects import Transform
-from pyworkflow.protocol.params import PointerParam, EnumParam, PathParam
-from pyworkflow.utils.path import createAbsLink, copyFile
-from pwem import Domain
-
+from pyworkflow.utils.path import createAbsLink
 
 from .protocol_base import ProtTomoImportFiles, ProtTomoImportAcquisition
 from ..objects import SubTomogram
@@ -47,7 +44,6 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
 
     IMPORT_FROM_AUTO = 0
     IMPORT_FROM_EMAN = 1
-    IMPORT_FROM_DYNAMO = 2
 
     def __init__(self, **args):
         ProtTomoImportFiles.__init__(self, **args)
@@ -57,18 +53,13 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
         from which the import can be done.
         (usually packages formats such as: xmipp3, eman2, relion...etc.
         """
-        return [' ', 'Eman', 'Dynamo']
+        return [' ', 'Eman']
 
     def _getDefaultChoice(self):
         return self.IMPORT_FROM_AUTO
 
     def _defineParams(self, form):
         ProtTomoImportFiles._defineParams(self, form)
-
-        form.addParam('tablePath', PathParam,
-                      label="Dynamo table file:", allowsNull=True, condition='importFrom == 2',
-                      help='Select dynamo table (.tbl) to link dynamo metadata to the subtomograms that will be '
-                           'imported to Scipion. ')
 
         # form.addParam('importCoordinates', PointerParam,
         #               pointerClass='SetOfCoordinates3D',
@@ -171,21 +162,12 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
         importFrom = self.importFrom.get()
         if importFrom == self.IMPORT_FROM_EMAN:
             pass  # TODO: read .hdf5 header (EMAN)
-        if importFrom == self.IMPORT_FROM_DYNAMO:
-            readDynTable = Domain.importFromPlugin("dynamo.convert.convert", "readDynTable")
-            readDynTable(self, subtomo)
 
     def _openMetadataFile(self):
         importFrom = self.importFrom.get()
-        if importFrom == self.IMPORT_FROM_DYNAMO:
-            dynTable = self._getExtraPath('dynamo_table.tbl')
-            copyFile(self.tablePath.get(), dynTable)
-            self.fhTable = open(dynTable, 'r')
 
     def _closeMetadataFile(self):
         importFrom = self.importFrom.get()
-        if importFrom == self.IMPORT_FROM_DYNAMO:
-            self.fhTable.close()
 
     def createOutput(self):
         self._defineOutputs(outputSubTomograms=self.subtomoSet)

--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -42,21 +42,8 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
     _outputClassName = 'SetOfSubTomograms'
     _label = 'import subtomograms'
 
-    IMPORT_FROM_AUTO = 0
-    IMPORT_FROM_EMAN = 1
-
     def __init__(self, **args):
         ProtTomoImportFiles.__init__(self, **args)
-
-    def _getImportChoices(self):
-        """ Return a list of possible choices
-        from which the import can be done.
-        (usually packages formats such as: xmipp3, eman2, relion...etc.
-        """
-        return [' ', 'Eman']
-
-    def _getDefaultChoice(self):
-        return self.IMPORT_FROM_AUTO
 
     def _defineParams(self, form):
         ProtTomoImportFiles._defineParams(self, form)
@@ -98,8 +85,6 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
         self.subtomoSet = self._createSetOfSubTomograms()
         self.subtomoSet.setSamplingRate(samplingRate)
 
-        self._openMetadataFile()  # Open the metadata file associated to the software used
-
         # if self.importCoordinates.get():
         #     self.coords = []
         #     for coord3D in self.importCoordinates.get().iterCoordinates():
@@ -139,8 +124,6 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
                 for index in range(1, n+1):
                     self._addSubtomogram(subtomo, fileName, newFileName, index=index)
 
-        self._closeMetadataFile()  # Close the metadata file associated to the software used
-
     def _addSubtomogram(self, subtomo, fileName, newFileName, index=None):
         """ adds a subtomogram to a set """
         subtomo.cleanObjId()
@@ -151,23 +134,7 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
 
         subtomo.setAcquisition(self._extractAcquisitionParameters(fileName))
         # self._setCoordinates3D(subtomo)
-
-        self._importMetadata(subtomo)  # Select the import function from the software used
-
         self.subtomoSet.append(subtomo)
-
-    def _importMetadata(self, subtomo):
-
-        # TODO: This is a temporal solution to add different import functions from different plugins
-        importFrom = self.importFrom.get()
-        if importFrom == self.IMPORT_FROM_EMAN:
-            pass  # TODO: read .hdf5 header (EMAN)
-
-    def _openMetadataFile(self):
-        importFrom = self.importFrom.get()
-
-    def _closeMetadataFile(self):
-        importFrom = self.importFrom.get()
 
     def createOutput(self):
         self._defineOutputs(outputSubTomograms=self.subtomoSet)

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -600,15 +600,6 @@ class TestTomoImportSubTomograms(BaseTest):
         self.launchProtocol(protImport)
         return protImport
 
-    def _runImportDynSubTomograms(self):
-        protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
-                                      filesPath=self.subtomos,
-                                      samplingRate=1.35,
-                                      importFrom=2,
-                                      tablePath=self.table)
-        self.launchProtocol(protImport)
-        return protImport
-
     def test_import_sub_tomograms(self):
          protImport = self._runImportSubTomograms()
          output = getattr(protImport, 'outputSubTomograms', None)
@@ -642,23 +633,6 @@ class TestTomoImportSubTomograms(BaseTest):
          #         self.assertTrue(subtomo.getCoordinate3D().getZ() == 256)
 
          return output2
-
-    def test_import_dynamo_subtomograms(self):
-         protImport = self._runImportDynSubTomograms()
-         output = getattr(protImport, 'outputSubTomograms', None)
-         self.assertTrue(output.getSamplingRate() == 1.35)
-         self.assertTrue(output.getFirstItem().getSamplingRate() == 1.35)
-         self.assertTrue(output.getDim()[0] == 32)
-         self.assertTrue(output.getDim()[1] == 32)
-         self.assertTrue(output.getDim()[2] == 32)
-         # Metada from dynamo table:
-         self.assertTrue(output.getFirstItem().getObjId() == 4)
-         self.assertTrue(output.getFirstItem().getClassId() == 1)
-         self.assertTrue(output.getFirstItem().getAcquisition().getAngleMin() == -60)
-         self.assertTrue(output.getFirstItem().getAcquisition().getAngleMax() == 60)
-         self.assertTrue(output.getFirstItem().getCoordinate3D().getX() == 175)
-         self.assertTrue(output.getFirstItem().getCoordinate3D().getY() == 134)
-         self.assertTrue(output.getFirstItem().getCoordinate3D().getZ() == 115)
 
 
 class TestTomoSubSetsSubTomograms(BaseTest):


### PR DESCRIPTION
Remove from `protocol_import_subtomograms` the option `from Dynamo` (and test) in order to avoid dependencies, as agreeded. Now, the impor subtomograms from dynamo protocol is in `scipion-em-dynamo` plugin (https://github.com/scipion-em/scipion-em-dynamo/pull/15).