### PR TITLE
Fixed Import Subtomograms Test

### DIFF
--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -572,7 +572,6 @@ class TestTomoImportSubTomograms(BaseTest):
 
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
                                       filesPath=self.subtomos,
-                                      filesPattern="*name.hdf5",
                                       samplingRate=1.35)
                                       # importCoordinates=protImportCoordinates3d.outputCoordinates)
         self.launchProtocol(protImport)
@@ -596,7 +595,6 @@ class TestTomoImportSubTomograms(BaseTest):
 
         protImport = self.newProtocol(tomo.protocols.ProtImportSubTomograms,
                                       filesPath=self.subtomos,
-                                      filesPattern="base*.hdf5",
                                       samplingRate=1.35)
                                       # importCoordinates=protImportCoordinates3d.outputCoordinates)
         self.launchProtocol(protImport)


### PR DESCRIPTION
Removed `pattern` from the inputs provided when executing the subtomogram importer through its test to avoid errors in the path generation.