### PR TITLE
update for chimerax

### DIFF
--- a/tomo/viewers/__init__.py
+++ b/tomo/viewers/__init__.py
@@ -24,5 +24,5 @@
 # *
 # **************************************************************************
 
-from tomo.viewers.viewers_data import TomoDataViewer
-from tomo.viewers.viewer_tomograms import ViewerProtImportTomograms
+from .viewers_data import TomoDataViewer
+from .viewer_tomograms import ViewerProtImportTomograms

--- a/tomo/viewers/viewer_tomograms.py
+++ b/tomo/viewers/viewer_tomograms.py
@@ -128,8 +128,13 @@ class ViewerProtImportTomograms(EmProtocolViewer):
             f.write("open %s\n" % tmpFileNameBILD)
             f.write("cofr 0,0,0\n")  # set center of coordinates
             count = 1  # skip first model because is not a 3D map
-
+        oldFileName = ""
         for tomo in _setOfObjects:
+            fileName = tomo.getFileName()
+            if fileName == oldFileName:
+                continue
+            else:
+                oldFileName = fileName
             localTomo = os.path.abspath(ImageHandler.removeFileType(
                 tomo.getFileName()))
             if localTomo.endswith("stk"):


### PR DESCRIPTION
Modify the viewer so it can be used with chimerax (chimera is not longer supported by scipion). 

chimera visualization in devel was broken, I fixed it and then I updated it for chimeraX. Remember that  you will need to reinstall scipion-em-chimerax and the last version os scipion-em in order to run this PR.