### PR TITLE
Fi feature assign transofrmation matrix to set of tilt series

### DIFF
--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -23,7 +23,8 @@ Tomography = [
         ]}
 	]},
 	{"tag": "section", "text": "Preprocessing", "children": [
-	    {"tag": "protocol", "value": "ProtAssignTomo2Subtomo",   "text": "default"}
+	    {"tag": "protocol", "value": "ProtAssignTomo2Subtomo",   "text": "default"},
+   	    {"tag": "protocol", "value": "ProtAssignTransformationMatrixTiltSeries", "text": "default"}
 	]},
 	{"tag": "section", "text": "Subtomogram averaging", "children": []},
 	{"tag": "section", "text": "Postprocessing", "children": [

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -37,3 +37,4 @@ from .protocol_import_coordinates import ProtImportCoordinates3D
 from .protocol_alignment_assign_subtomo import ProtAlignmentAssignSubtomo
 from .protocol_extract_coordinates import ProtTomoExtractCoords
 from .protocol_assign_tomo2subtomo import ProtAssignTomo2Subtomo
+from .protocol_assignTransformationTS import ProtAssignTransformationMatrixTiltSeries

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -71,11 +71,8 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
     def generateOutputStackStep(self, tsObjId):
         outputAssignedTransformSetOfTiltSeries = self.getOutputAssignedTransformSetOfTiltSeries()
 
-        ts = self.inputSetOfTiltSeries.get()[tsObjId]
+        ts = self.assignTransformSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
-
-        extraPrefix = self._getExtraPath(tsId)
-        tmpPrefix = self._getTmpPath(tsId)
 
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
@@ -84,9 +81,8 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
         for index, tiltImage in enumerate(ts):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
-            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s.st' % tsId)))
-            if self.binning > 1:
-                newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
+            newTi.setLocation(tiltImage.getLocation())
+            newTi.setTransform(tiltImage.getTransform()s)
             newTs.append(newTi)
 
         ih = ImageHandler()

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -1,0 +1,187 @@
+# **************************************************************************
+# *
+# * Authors:     Federico P. de Isidro Gomez (fp.deisidro@cnb.csi.es) [1]
+# *
+# * [1] Centro Nacional de Biotecnologia, CSIC, Spain
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+import os
+import numpy as np
+import imod.utils as utils
+import pyworkflow.protocol.params as params
+import pyworkflow.utils.path as path
+from pwem.protocols import EMProtocol
+import tomo.objects as tomoObj
+from tomo.protocols import ProtTomoBase
+from imod import Plugin
+from pwem.emlib.image import ImageHandler
+
+
+class XmippProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
+    """
+    Compute the interpolated tilt-series from its transform matrix.
+    More info:
+        https://bio3D.colorado.edu/imod/doc/etomoTutorial.html
+    """
+
+    _label = 'assign alignment tilt-series'
+
+    # -------------------------- DEFINE param functions -----------------------
+    def _defineParams(self, form):
+        form.addSection('Input')
+        form.addParam('inputSetOfTiltSeries',
+                      params.PointerParam,
+                      pointerClass='SetOfTiltSeries',
+                      important=True,
+                      label='Input set of tilt-series')
+
+        form.addParam('assignTransformSetOfTiltSeries',
+                      params.PointerParam,
+                      pointerClass='SetOfTiltSeries',
+                      important=True,
+                      label='Input set of tilt-series')
+
+    # -------------------------- INSERT steps functions ---------------------
+    def _insertAllSteps(self):
+        for ts in self.inputSetOfTiltSeries.get():
+            self._insertFunctionStep('convertInputStep', ts.getObjId())
+            self._insertFunctionStep('generateTransformFileStep', ts.getObjId())
+            self._insertFunctionStep('generateOutputStackStep', ts.getObjId())
+
+    # --------------------------- STEPS functions ----------------------------
+    def convertInputStep(self, tsObjId):
+        ts = self.inputSetOfTiltSeries.get()[tsObjId]
+        tsId = ts.getTsId()
+        extraPrefix = self._getExtraPath(tsId)
+        tmpPrefix = self._getTmpPath(tsId)
+        path.makePath(tmpPrefix)
+        path.makePath(extraPrefix)
+        inputTsFileName = ts.getFirstItem().getLocation()[1]
+        outputTsFileName = os.path.join(tmpPrefix, "%s.st" % tsId)
+
+        """Create link to input stack"""
+        path.createLink(inputTsFileName, outputTsFileName)
+
+    def generateTransformFileStep(self, tsObjId):
+        ts = self.inputSetOfTiltSeries.get()[tsObjId]
+        tsId = ts.getTsId()
+        extraPrefix = self._getExtraPath(tsId)
+        if not ts.getFirstItem().hasTransform():
+            inputTsFilePath = ts.getFirstItem().getLocation()[1]
+            outputTsFilePath = os.path.join(extraPrefix, '%s.st' % tsId)
+            path.createLink(inputTsFilePath, outputTsFilePath)
+        else:
+            utils.formatTransformFile(ts, os.path.join(extraPrefix, "%s.prexg" % tsId))
+
+    def generateOutputStackStep(self, tsObjId):
+        outputInterpolatedSetOfTiltSeries = self.getOutputInterpolatedSetOfTiltSeries()
+
+        ts = self.inputSetOfTiltSeries.get()[tsObjId]
+        tsId = ts.getTsId()
+
+        extraPrefix = self._getExtraPath(tsId)
+        tmpPrefix = self._getTmpPath(tsId)
+
+        if ts.getFirstItem().hasTransform():
+            paramsAlignment = {
+                'input': os.path.join(tmpPrefix, '%s.st' % tsId),
+                'output': os.path.join(extraPrefix, '%s.st' % tsId),
+                'xform': os.path.join(extraPrefix, "%s.prexg" % tsId),
+                'bin': int(self.binning.get()),
+                'imagebinned': 1.0}
+
+            argsAlignment = "-input %(input)s " \
+                            "-output %(output)s " \
+                            "-xform %(xform)s " \
+                            "-bin %(bin)d " \
+                            "-imagebinned %(imagebinned)s"
+            Plugin.runImod(self, 'newstack', argsAlignment % paramsAlignment)
+
+        newTs = tomoObj.TiltSeries(tsId=tsId)
+        newTs.copyInfo(ts)
+        outputInterpolatedSetOfTiltSeries.append(newTs)
+
+        if self.binning > 1:
+            newTs.setSamplingRate(ts.getSamplingRate() * int(self.binning.get()))
+
+        for index, tiltImage in enumerate(ts):
+            newTi = tomoObj.TiltImage()
+            newTi.copyInfo(tiltImage, copyId=True)
+            newTi.setLocation(index + 1, (os.path.join(extraPrefix, '%s.st' % tsId)))
+            if self.binning > 1:
+                newTi.setSamplingRate(tiltImage.getSamplingRate() * int(self.binning.get()))
+            newTs.append(newTi)
+
+        ih = ImageHandler()
+        x, y, z, _ = ih.getDimensions(newTs.getFirstItem().getFileName())
+        newTs.setDim((x, y, z))
+        newTs.write()
+
+        outputInterpolatedSetOfTiltSeries.update(newTs)
+        outputInterpolatedSetOfTiltSeries.updateDim()
+        outputInterpolatedSetOfTiltSeries.write()
+        self._store()
+
+    # --------------------------- UTILS functions ----------------------------
+    def getOutputInterpolatedSetOfTiltSeries(self):
+        if not hasattr(self, "outputInterpolatedSetOfTiltSeries"):
+            outputInterpolatedSetOfTiltSeries = self._createSetOfTiltSeries(suffix='Interpolated')
+            outputInterpolatedSetOfTiltSeries.copyInfo(self.inputSetOfTiltSeries.get())
+            outputInterpolatedSetOfTiltSeries.setDim(self.inputSetOfTiltSeries.get().getDim())
+            if self.binning > 1:
+                samplingRate = self.inputSetOfTiltSeries.get().getSamplingRate()
+                samplingRate *= self.binning.get()
+                outputInterpolatedSetOfTiltSeries.setSamplingRate(samplingRate)
+            self._defineOutputs(outputInterpolatedSetOfTiltSeries=outputInterpolatedSetOfTiltSeries)
+            self._defineSourceRelation(self.inputSetOfTiltSeries, outputInterpolatedSetOfTiltSeries)
+        return self.outputInterpolatedSetOfTiltSeries
+
+    # --------------------------- INFO functions ----------------------------
+    def _validate(self):
+        validateMsgs = []
+
+        for ts in self.inputSetOfTiltSeries.get():
+            if not ts.getFirstItem().getFirstItem().hasCTF():
+                validateMsgs = "Some tilt-series from the input set of tilt-series does not have a transformation " \
+                               "matrix assigned"
+
+        return validateMsgs
+
+    def _summary(self):
+        summary = []
+        if hasattr(self, 'outputInterpolatedSetOfTiltSeries'):
+            summary.append("Input Tilt-Series: %d.\nInterpolations applied: %d.\n"
+                           % (self.inputSetOfTiltSeries.get().getSize(),
+                              self.outputInterpolatedSetOfTiltSeries.getSize()))
+        else:
+            summary.append("Output classes not ready yet.")
+        return summary
+
+    def _methods(self):
+        methods = []
+        if hasattr(self, 'outputInterpolatedSetOfTiltSeries'):
+            methods.append("The interpolation has been computed for %d "
+                           "Tilt-series using the IMOD newstack program.\n"
+                           % (self.outputInterpolatedSetOfTiltSeries.getSize()))
+        else:
+            methods.append("Output classes not ready yet.")
+        return methods

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -26,13 +26,12 @@
 
 import os
 import numpy as np
-import imod.utils as utils
+import itertools
 import pyworkflow.protocol.params as params
 import pyworkflow.utils.path as path
 from pwem.protocols import EMProtocol
 import tomo.objects as tomoObj
 from tomo.protocols import ProtTomoBase
-from imod import Plugin
 from pwem.emlib.image import ImageHandler
 
 
@@ -72,17 +71,18 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
         outputAssignedTransformSetOfTiltSeries = self.getOutputAssignedTransformSetOfTiltSeries()
 
         ts = self.assignTransformSetOfTiltSeries.get()[tsObjId]
+        tsTM = self.inputSetOfTiltSeries.get()[tsObjId]
         tsId = ts.getTsId()
 
         newTs = tomoObj.TiltSeries(tsId=tsId)
         newTs.copyInfo(ts)
         outputAssignedTransformSetOfTiltSeries.append(newTs)
 
-        for index, tiltImage in enumerate(ts):
+        for tiltImage, tiltImageTM in zip(ts, tsTM):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
             newTi.setLocation(tiltImage.getLocation())
-            newTi.setTransform(tiltImage.getTransform())
+            newTi.setTransform(tiltImageTM.getTransform())
             newTs.append(newTi)
 
         ih = ImageHandler()

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -36,14 +36,14 @@ from imod import Plugin
 from pwem.emlib.image import ImageHandler
 
 
-class XmippProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
+class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
     """
     Compute the interpolated tilt-series from its transform matrix.
     More info:
         https://bio3D.colorado.edu/imod/doc/etomoTutorial.html
     """
 
-    _label = 'assign alignment tilt-series'
+    _label = 'Tilt-series assign alignment'
 
     # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -37,9 +37,7 @@ from pwem.emlib.image import ImageHandler
 
 class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
     """
-    Compute the interpolated tilt-series from its transform matrix.
-    More info:
-        https://bio3D.colorado.edu/imod/doc/etomoTutorial.html
+    Assign the transformation matrices from an input set of tilt-series to a target one.
     """
 
     _label = 'Tilt-series assign alignment'

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -58,13 +58,12 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
                       params.PointerParam,
                       pointerClass='SetOfTiltSeries',
                       important=True,
-                      label='Input set of tilt-series')
+                      label='Assign transformation set of tilt-series')
 
     # -------------------------- INSERT steps functions ---------------------
     def _insertAllSteps(self):
         for ts in self.inputSetOfTiltSeries.get():
             self._insertFunctionStep('convertInputStep', ts.getObjId())
-            self._insertFunctionStep('generateTransformFileStep', ts.getObjId())
             self._insertFunctionStep('generateOutputStackStep', ts.getObjId())
 
     # --------------------------- STEPS functions ----------------------------
@@ -80,17 +79,6 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
 
         """Create link to input stack"""
         path.createLink(inputTsFileName, outputTsFileName)
-
-    def generateTransformFileStep(self, tsObjId):
-        ts = self.inputSetOfTiltSeries.get()[tsObjId]
-        tsId = ts.getTsId()
-        extraPrefix = self._getExtraPath(tsId)
-        if not ts.getFirstItem().hasTransform():
-            inputTsFilePath = ts.getFirstItem().getLocation()[1]
-            outputTsFilePath = os.path.join(extraPrefix, '%s.st' % tsId)
-            path.createLink(inputTsFilePath, outputTsFilePath)
-        else:
-            utils.formatTransformFile(ts, os.path.join(extraPrefix, "%s.prexg" % tsId))
 
     def generateOutputStackStep(self, tsObjId):
         outputInterpolatedSetOfTiltSeries = self.getOutputInterpolatedSetOfTiltSeries()
@@ -160,9 +148,18 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
         validateMsgs = []
 
         for ts in self.inputSetOfTiltSeries.get():
-            if not ts.getFirstItem().getFirstItem().hasCTF():
+            if not ts.getFirstItem().hasTransform():
                 validateMsgs = "Some tilt-series from the input set of tilt-series does not have a transformation " \
-                               "matrix assigned"
+                               "matrix assigned."
+
+            if ts.getSize() != self.assignTransformSetOfTiltSeries.get()[ts.getObjId()].getSize():
+                validateMsgs = "Some tilt-series from the input set of tilt-series and its target in the assign " \
+                               "transfomration set of tilt-series size's do not match. Every input tilt-series and " \
+                               "its target must have the same number of elements" \
+
+        if self.inputSetOfTiltSeries.get().getSize() != self.assignTransformSetOfTiltSeries.get().getSize():
+            validateMsgs = "Both input sets of tilt-series size's do not match. Both sets must have the same number " \
+                           "of elements."
 
         return validateMsgs
 

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -63,23 +63,9 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
     # -------------------------- INSERT steps functions ---------------------
     def _insertAllSteps(self):
         for ts in self.inputSetOfTiltSeries.get():
-            self._insertFunctionStep('convertInputStep', ts.getObjId())
-            self._insertFunctionStep('generateOutputStackStep', ts.getObjId())
+            self._insertFunctionStep('assignTransformationMatricesStep', ts.getObjId())
 
     # --------------------------- STEPS functions ----------------------------
-    def convertInputStep(self, tsObjId):
-        ts = self.inputSetOfTiltSeries.get()[tsObjId]
-        tsId = ts.getTsId()
-        extraPrefix = self._getExtraPath(tsId)
-        tmpPrefix = self._getTmpPath(tsId)
-        path.makePath(tmpPrefix)
-        path.makePath(extraPrefix)
-        inputTsFileName = ts.getFirstItem().getLocation()[1]
-        outputTsFileName = os.path.join(tmpPrefix, "%s.st" % tsId)
-
-        """Create link to input stack"""
-        path.createLink(inputTsFileName, outputTsFileName)
-
     def generateOutputStackStep(self, tsObjId):
         outputInterpolatedSetOfTiltSeries = self.getOutputInterpolatedSetOfTiltSeries()
 

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -110,17 +110,17 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
 
         for ts in self.inputSetOfTiltSeries.get():
             if not ts.getFirstItem().hasTransform():
-                validateMsgs = "Some tilt-series from the input set of tilt-series does not have a transformation " \
-                               "matrix assigned."
+                validateMsgs.append("Some tilt-series from the input set of tilt-series does not have a "
+                                    "transformation matrix assigned.")
 
             if ts.getSize() != self.assignTransformSetOfTiltSeries.get()[ts.getObjId()].getSize():
-                validateMsgs = "Some tilt-series from the input set of tilt-series and its target in the assign " \
-                               "transfomration set of tilt-series size's do not match. Every input tilt-series and " \
-                               "its target must have the same number of elements" \
+                validateMsgs.append("Some tilt-series from the input set of tilt-series and its target in the assign "
+                                    "transfomration set of tilt-series size's do not match. Every input tilt-series "
+                                    "and its target must have the same number of elements")
 
         if self.inputSetOfTiltSeries.get().getSize() != self.assignTransformSetOfTiltSeries.get().getSize():
-            validateMsgs = "Both input sets of tilt-series size's do not match. Both sets must have the same number " \
-                           "of elements."
+            validateMsgs.append("Both input sets of tilt-series size's do not match. Both sets must have the same "
+                                "number of elements.")
 
         return validateMsgs
 

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -82,7 +82,7 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
             newTi = tomoObj.TiltImage()
             newTi.copyInfo(tiltImage, copyId=True)
             newTi.setLocation(tiltImage.getLocation())
-            newTi.setTransform(tiltImage.getTransform()s)
+            newTi.setTransform(tiltImage.getTransform())
             newTs.append(newTi)
 
         ih = ImageHandler()

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -68,7 +68,7 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtTomoBase):
             self._insertFunctionStep('assignTransformationMatricesStep', ts.getObjId())
 
     # --------------------------- STEPS functions ----------------------------
-    def generateOutputStackStep(self, tsObjId):
+    def assignTransformationMatricesStep(self, tsObjId):
         outputAssignedTransformSetOfTiltSeries = self.getOutputAssignedTransformSetOfTiltSeries()
 
         ts = self.assignTransformSetOfTiltSeries.get()[tsObjId]


### PR DESCRIPTION
This PR includes:

- New protocol to assign transformation matrices from one set of tilt-series to another
- Changes needed in init and protocols.conf