### PR TITLE
Picking Consensus and Remove Duplicates

### DIFF
--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -19,7 +19,8 @@ Tomography = [
 	{"tag": "section", "text": "Reconstruction", "children": []},
 	{"tag": "section", "text": "Particles", "children": [
 	    {"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
-            {"tag": "protocol", "value": "ProtTomoExtractCoords",   "text": "default"}
+            {"tag": "protocol", "value": "ProtTomoExtractCoords",   "text": "default"},
+            {"tag": "protocol", "value": "ProtTomoConsensusPicking",   "text": "default"}
         ]}
 	]},
 	{"tag": "section", "text": "Preprocessing", "children": [

--- a/tomo/protocols.conf
+++ b/tomo/protocols.conf
@@ -20,7 +20,8 @@ Tomography = [
 	{"tag": "section", "text": "Particles", "children": [
 	    {"tag": "protocol_group", "text": "Picking", "openItem": "False", "children": [
             {"tag": "protocol", "value": "ProtTomoExtractCoords",   "text": "default"},
-            {"tag": "protocol", "value": "ProtTomoConsensusPicking",   "text": "default"}
+            {"tag": "protocol", "value": "ProtTomoConsensusPicking",   "text": "default"},
+            {"tag": "protocol", "value": "ProtTomoPickingRemoveDuplicates",   "text": "default"}
         ]}
 	]},
 	{"tag": "section", "text": "Preprocessing", "children": [

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -38,3 +38,4 @@ from .protocol_alignment_assign_subtomo import ProtAlignmentAssignSubtomo
 from .protocol_extract_coordinates import ProtTomoExtractCoords
 from .protocol_assign_tomo2subtomo import ProtAssignTomo2Subtomo
 from .protocol_assignTransformationTS import ProtAssignTransformationMatrixTiltSeries
+from .protocol_particle_pick_consensus import ProtTomoConsensusPicking

--- a/tomo/protocols/__init__.py
+++ b/tomo/protocols/__init__.py
@@ -39,3 +39,4 @@ from .protocol_extract_coordinates import ProtTomoExtractCoords
 from .protocol_assign_tomo2subtomo import ProtAssignTomo2Subtomo
 from .protocol_assignTransformationTS import ProtAssignTransformationMatrixTiltSeries
 from .protocol_particle_pick_consensus import ProtTomoConsensusPicking
+from .protocol_particle_pick_remove_duplicates import ProtTomoPickingRemoveDuplicates

--- a/tomo/protocols/protocol_particle_pick_consensus.py
+++ b/tomo/protocols/protocol_particle_pick_consensus.py
@@ -85,12 +85,14 @@ class ProtTomoConsensusPicking(ProtTomoPicking):
                            "are presumed to correspond to the same particle")
         form.addParam('consensus', params.IntParam, default=-1,
                       label="Consensus",
-                      help="How many times need a particle to be selected to "
-                           "be considered as a consensus particle.\n"
+                      help="This parameter can take values from 1 to total number of inputs (being "
+                           "-1 a special case).\n"
                            "*Set to -1* to indicate that it needs to be selected "
                            "by all algorithms: *AND* operation.\n"
                            "*Set to 1* to indicate that it suffices that only "
-                           "1 algorithm selects the particle: *OR* operation.")
+                           "1 algorithm selects the particle: *OR* operation.\n"
+                           "Any other value will determine how many times need a particle"
+                           " to be selected to be considered as a consensus particle.")
         form.addParam('mode', params.EnumParam, label='Consensus mode',
                       choices=['>=', '='], default=PICK_MODE_LARGER,
                       expertLevel=LEVEL_ADVANCED,

--- a/tomo/protocols/protocol_particle_pick_consensus.py
+++ b/tomo/protocols/protocol_particle_pick_consensus.py
@@ -228,6 +228,7 @@ class ProtTomoConsensusPicking(ProtTomoPicking):
             outputSet = SetClass(filename=setFile)
             outputSet.setStreamState(outputSet.STREAM_OPEN)
             outputSet.setBoxSize(self.getMainInput().getBoxSize())
+            outputSet.setSamplingRate(self.getMainInput().getSamplingRate())
 
         #inMicsPointer = Pointer(self.getMapper().getParent(
         #                                    self.getMainInput().getMicrographs()),

--- a/tomo/protocols/protocol_particle_pick_consensus.py
+++ b/tomo/protocols/protocol_particle_pick_consensus.py
@@ -94,6 +94,7 @@ class ProtTomoConsensusPicking(ProtTomoPicking):
         form.addParam('mode', params.EnumParam, label='Consensus mode',
                       choices=['>=', '='], default=PICK_MODE_LARGER,
                       expertLevel=LEVEL_ADVANCED,
+                      display=params.EnumParam.DISPLAY_HLIST,
                       help='If the number of votes to progress to the output '
                            'must be either (=) strictly speaking equals to '
                            'the consensus number or (>=) at least equals.')

--- a/tomo/protocols/protocol_particle_pick_consensus.py
+++ b/tomo/protocols/protocol_particle_pick_consensus.py
@@ -1,0 +1,397 @@
+# **************************************************************************
+# *
+# * Authors:    Carlos Oscar Sorzano (coss@cnb.csic.es)
+# *             Tomas Majtner (tmajtner@cnb.csic.es)  -- streaming version
+# *             David Herreros Calero (dherreros@cnb.csic.es) -- Tomo version
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'coss@cnb.csic.es'
+# *
+# **************************************************************************
+"""
+Consensus picking protocol
+"""
+
+import os
+
+from math import sqrt
+import numpy as np
+
+from pyworkflow.object import Set, String, Pointer
+import pyworkflow.protocol.params as params
+from pyworkflow.protocol.constants import *
+from pwem.objects import SetOfCoordinates, Coordinate
+from pyworkflow.utils import getFiles, removeBaseExt, moveFile
+
+from tomo.protocols import ProtTomoPicking
+
+PICK_MODE_LARGER = 0
+PICK_MODE_EQUAL = 1
+
+class ProtTomoConsensusPicking(ProtTomoPicking):
+    """
+    Protocol to estimate the agreement between different particle picking
+    algorithms. The protocol takes several Sets of Coordinates calculated
+    by different programs and/or different parameter settings. Let's say:
+    we consider N independent pickings. Then, a coordinate is considered
+    to be a correct particle if M pickers have selected the same particle
+    (within a radius in pixels specified in the form).
+
+    If you want to be very strict, then set M=N; that is, a coordinate
+    represents a particle if it has been selected by all particles (this
+    is the default behaviour). Then you may relax this condition by setting
+    M=N-1, N-2, ...
+
+    If you want to be very flexible, set M=1, in this way it suffices that
+    1 picker has selected the coordinate to be considered as a particle. Note
+    that in this way, the cleaning of the dataset has to be performed by other
+    means (screen particles, 2D and 3D classification, ...).
+    """
+
+    _label = 'picking consensus'
+    outputName = 'consensusCoordinates'
+    FN_PREFIX = 'consensusCoords_'
+
+    def __init__(self, **args):
+        ProtTomoPicking.__init__(self, **args)
+        self.stepsExecutionMode = STEPS_SERIAL
+
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputCoordinates', params.MultiPointerParam,
+                      pointerClass='SetOfCoordinates3D',
+                      label="Input 3D coordinates", important=True,
+                      help='Select the set of 3D coordinates to compare')
+        form.addParam('consensusRadius', params.IntParam, default=10,
+                      label="Radius",
+                      help="All coordinates within this radius (in pixels) "
+                           "are presumed to correspond to the same particle")
+        form.addParam('consensus', params.IntParam, default=-1,
+                      label="Consensus",
+                      help="How many times need a particle to be selected to "
+                           "be considered as a consensus particle.\n"
+                           "*Set to -1* to indicate that it needs to be selected "
+                           "by all algorithms: *AND* operation.\n"
+                           "*Set to 1* to indicate that it suffices that only "
+                           "1 algorithm selects the particle: *OR* operation.")
+        form.addParam('mode', params.EnumParam, label='Consensus mode',
+                      choices=['>=', '='], default=PICK_MODE_LARGER,
+                      expertLevel=LEVEL_ADVANCED,
+                      help='If the number of votes to progress to the output '
+                           'must be either (=) strictly speaking equals to '
+                           'the consensus number or (>=) at least equals.')
+
+        # FIXME: It's not using more than one since
+        #         self.stepsExecutionMode = STEPS_SERIAL
+        # form.addParallelSection(threads=4, mpi=0)
+
+#--------------------------- INSERT steps functions ---------------------------
+    def _insertAllSteps(self):
+        self.checkedTomos = set()   # those tomos ready to be processed (tomoId)
+        self.processedTomos = set() # those tomos already processed (tomoId)
+        self.sampligRates = []
+        coorSteps = self.insertNewCoorsSteps([])
+        self._insertFunctionStep('createOutputStep',
+                                 prerequisites=coorSteps, wait=True)
+
+    def createOutputStep(self):
+        pass
+
+    def _getFirstJoinStepName(self):
+        # This function will be used for streaming, to check which is
+        # the first function that need to wait for all mics
+        # to have completed, this can be overriden in subclasses
+        # (e.g., in Xmipp 'sortPSDStep')
+        return 'createOutputStep'
+
+    def _getFirstJoinStep(self):
+        for s in self._steps:
+            if s.funcName == self._getFirstJoinStepName():
+                return s
+        return None
+
+    def insertNewCoorsSteps(self, tomos):
+        deps = []
+        for tomo in tomos:
+            stepId = self._insertFunctionStep("calculateConsensusStep",
+                                              tomo.getObjId(),
+                                              tomo.getFileName(),
+                                              prerequisites=[])
+            deps.append(stepId)
+        return deps
+
+    def _stepsCheck(self):
+        self._checkNewInput()
+        self._checkNewOutput()
+
+    def _checkNewInput(self):
+        # If continue from an stopped run, don't repeat what is done
+        if not self.checkedTomos:
+            for fn in getFiles(self._getExtraPath()):
+                fn = removeBaseExt(fn)
+                if fn.startswith(self.FN_PREFIX):
+                    self.checkedTomos.update([self.getTomoId(fn)])
+                    self.processedTomos.update([self.getTomoId(fn)])
+
+        streamClosed = []
+        readyMics = None
+        allMics = set()
+        for coordSet in self.inputCoordinates:
+            currentPickMics, isSetClosed = getReadyMics(coordSet.get())
+            streamClosed.append(isSetClosed)
+            if not readyMics:  # first time
+                readyMics = currentPickMics
+            else:  # available mics are those ready for all pickers
+                readyMics.intersection_update(currentPickMics)
+            allMics = allMics.union(currentPickMics)
+
+        self.streamClosed = all(streamClosed)
+        if self.streamClosed:
+            # for non streaming do all and in the last iteration of streaming do the rest
+            newTomoIds = allMics.difference(self.checkedTomos)
+        else:  # for streaming processing, only go for the ready mics in all pickers
+            newTomoIds = readyMics.difference(self.checkedTomos)
+
+        if newTomoIds:
+            self.checkedTomos.update(newTomoIds)
+
+            inTomos = self.getMainInput().getPrecedents()
+            newTomos = [inTomos[tomoId].clone() for tomoId in newTomoIds]
+
+            fDeps = self.insertNewCoorsSteps(newTomos)
+            outputStep = self._getFirstJoinStep()
+            if outputStep is not None:
+                outputStep.addPrerequisites(*fDeps)
+            self.updateSteps()
+
+    def _checkNewOutput(self):
+        if getattr(self, 'finished', False):
+            return
+        self.finished = self.streamClosed and self.checkedTomos == self.processedTomos
+        streamMode = Set.STREAM_CLOSED if self.finished else Set.STREAM_OPEN
+
+        newFiles = getFiles(self._getTmpPath())
+        if newFiles or self.finished:  # when finished to close the output set
+            outSet = self._loadOutputSet(SetOfCoordinates, 'coordinates.sqlite')
+
+            for fnTmp in newFiles:
+                coords = np.loadtxt(fnTmp)
+                moveFile(fnTmp, self._getExtraPath())
+                if coords.size == 2:  # special case with only one coordinate
+                    coords = [coords]
+                for coord in coords:
+                    newCoord = Coordinate()
+                    micrographs = self.getMainInput().getMicrographs()
+                    newCoord.setMicrograph(micrographs[self.getTomoId(fnTmp)])
+                    newCoord.setPosition(coord[0], coord[1])
+                    outSet.append(newCoord)
+
+            firstTime = not self.hasAttribute(self.outputName)
+            self._updateOutputSet(self.outputName, outSet, streamMode)
+            if firstTime:
+                self.defineRelations(outSet)
+            outSet.close()
+
+        if self.finished:  # Unlock createOutputStep if finished all jobs
+            outputStep = self._getFirstJoinStep()
+            if outputStep and outputStep.isWaiting():
+                outputStep.setStatus(STATUS_NEW)
+
+    def defineRelations(self, outputSet):
+        for inCorrds in self.inputCoordinates:
+            self._defineTransformRelation(inCorrds, outputSet)
+
+    def _loadOutputSet(self, SetClass, baseName):
+        setFile = self._getPath(baseName)
+        if os.path.exists(setFile):
+            outputSet = SetClass(filename=setFile)
+            outputSet.loadAllProperties()
+            outputSet.enableAppend()
+        else:
+            outputSet = SetClass(filename=setFile)
+            outputSet.setStreamState(outputSet.STREAM_OPEN)
+            outputSet.setBoxSize(self.getMainInput().getBoxSize())
+
+        #inMicsPointer = Pointer(self.getMapper().getParent(
+        #                                    self.getMainInput().getMicrographs()),
+        #                                    extended='outputMicrographs')
+        inMicsPointer = Pointer(self.getMainInput().getMicrographs())
+        outputSet.setMicrographs(inMicsPointer)
+
+        return outputSet
+
+    def calculateConsensusStep(self, tomoId, tomoName):
+
+        print("Consensus calculation for Tomogram %d: '%s'"
+              % (tomoId, tomoName))
+
+        # Take the sampling rates just once
+        if not self.sampligRates:
+            for coordinates in self.inputCoordinates:
+                tomograms = coordinates.get().getPrecedents()
+                self.sampligRates.append(tomograms.getSamplingRate())
+
+        # Get all coordinates for this tomogram
+        coords = []
+        for idx, coordinates in enumerate(self.inputCoordinates):
+            coordArray = np.asarray([x.getPosition() for x in
+                                     coordinates.get().iterCoordinates(tomoId)],
+                                     dtype=float)
+            coordArray *= float(self.sampligRates[idx]) / float(self.sampligRates[0])
+            coords.append(np.asarray(coordArray, dtype=int))
+
+        consensusWorker(coords, self.consensus.get(), self.consensusRadius.get(),
+                        self._getTmpPath('%s%s.txt' % (self.FN_PREFIX, tomoId)),
+                        self._getExtraPath('jaccard.txt'), self.mode.get())
+
+        self.processedMics.update([tomoId])
+
+    def _validate(self):
+
+        errors = []
+
+        # Only for Scipion 2.0, next versions should have the default
+        # PointerList validation and this can be removed
+        if len(self.inputCoordinates) == 0:
+                errors.append('inputCoordinates cannot be EMPTY.')
+        # Consider empty pointers:
+        else:
+            for pointer in self.inputCoordinates:
+                obj = pointer.get()
+                if obj is None:
+                    errors.append('%s is empty.' % obj)
+
+        return errors
+
+    def _summary(self):
+        message = []
+        for i, coordinates in enumerate(self.inputCoordinates):
+            protocol = self.getMapper().getParent(coordinates.get())
+            message.append("Method %d %s" % (i + 1, protocol.getClassLabel()))
+        message.append("Radius = %d" % self.consensusRadius)
+        message.append("Consensus = %d" % self.consensus)
+        return message
+
+    def _methods(self):
+        return []
+
+    def getMainInput(self):
+        return self.inputCoordinates[0].get()
+
+    @classmethod
+    def getTomoId(self, fn):
+        return int(removeBaseExt(fn).lstrip(self.FN_PREFIX))
+
+
+def consensusWorker(coords, consensus, consensusRadius, posFn, jaccFn=None,
+                    mode=PICK_MODE_LARGER):
+    """ Worker for calculate the consensus of N picking algorithms of
+          M_n coordinates each one.
+
+        coords: Array of N numpy arrays of M_n coordinates each one.
+        consensus: Minimum number of votes to get a consensus coordinate
+        consensusRadius: Tolerance to see two coordinates as the same (in pixels)
+        posFn: Where to write the consensus coordinates
+        jaccFN: Where to write the Jaccard index per micrograph
+    """
+    if len(coords) == 1:  # self consensus (remove duplicates)
+        N0 = 0
+        firstInput = 0
+    else:  # in regular consensus all first coords are directly added to allCoords
+        N0 = coords[0].shape[0]
+        firstInput = 1
+
+    # initializing arrays
+    Ninputs = len(coords)
+    Ncoords = sum([x.shape[0] for x in coords])
+    allCoords = np.zeros([Ncoords, 3])
+    votes = np.zeros(Ncoords)
+
+    inAllMicrographs = consensus <= 0 or consensus >= Ninputs
+
+    # if nothing in the first and it should be in all, nothing to do
+    if (not all([coords[idx].shape[0] for idx in range(Ninputs)])
+            and inAllMicrographs):
+        print("Returning from worker: doing AND consensus and, at least, one "
+              "picker is empty for this micrograph (%s)." % posFn)
+        return
+
+    # Add all the first coordinates to 'allCoords' and 'votes' lists
+    if N0 > 0:
+        allCoords[0:N0, :] = coords[0]
+        votes[0:N0] = 1
+
+    # Add the rest of coordinates to 'allCoords' and 'votes' lists
+    Ncurrent = N0
+    for n in range(firstInput, Ninputs):
+        for coord in coords[n]:
+            if Ncurrent > 0:
+                dist = np.sum((coord - allCoords[0:Ncurrent]) ** 2, axis=1)
+                imin = np.argmin(dist)
+                if sqrt(dist[imin]) < consensusRadius:
+                    newCoord = (votes[imin] * allCoords[imin,] + coord) / (
+                                        votes[imin] + 1)
+                    allCoords[imin,] = newCoord
+                    votes[imin] += 1
+                else:
+                    allCoords[Ncurrent, :] = coord
+                    votes[Ncurrent] = 1
+                    Ncurrent += 1
+            else:
+                allCoords[Ncurrent, :] = coord
+                votes[Ncurrent] = 1
+                Ncurrent += 1
+
+    # Select those in the consensus
+    if consensus <= 0 or consensus > Ninputs:
+        consensus = Ninputs
+    elif not isinstance(consensus, int):
+        consensus = consensus.get()
+
+    if mode==PICK_MODE_LARGER:
+        consensusCoords = allCoords[votes >= consensus, :]
+    else:
+        consensusCoords = allCoords[votes == consensus, :]
+
+    try:
+        if jaccFn:
+            jaccardIdx = float(len(consensusCoords)) / (
+                    float(len(allCoords)) / Ninputs)
+            # COSS: Possible problem with concurrent writes
+            with open(jaccFn, "a") as fhJaccard:
+                fhJaccard.write("%s \t %f\n" % (posFn, jaccardIdx))
+    except Exception as exc:
+        print("Some error occurred during Jaccard index calculation or "
+              "writing it's file. Maybe a concurrence issue:\n%s" % exc)
+    # Write the consensus file only if there
+    # are some coordinates (size > 0)
+    if consensusCoords.size:
+        np.savetxt(posFn, consensusCoords)
+
+
+def getReadyMics(coordSet):
+    coorSet = SetOfCoordinates(filename=coordSet.getFileName())
+    coorSet._xmippMd = String()
+    coorSet.loadAllProperties()
+    setClosed = coorSet.isStreamClosed()
+    coorSet.close()
+    currentPickMics = {micAgg["_micId"] for micAgg in
+                       coordSet.aggregate(["MAX"], "_micId", ["_micId"])}
+    return currentPickMics, setClosed

--- a/tomo/protocols/protocol_particle_pick_consensus.py
+++ b/tomo/protocols/protocol_particle_pick_consensus.py
@@ -34,7 +34,7 @@ import os
 from math import sqrt
 import numpy as np
 
-from pyworkflow.object import Set, String, Pointer
+from pyworkflow.object import Set, Pointer
 import pyworkflow.protocol.params as params
 from pyworkflow.protocol.constants import *
 from pyworkflow.utils import getFiles, removeBaseExt, moveFile
@@ -151,23 +151,23 @@ class ProtTomoConsensusPicking(ProtTomoPicking):
                     self.processedTomos.update([self.getTomoId(fn)])
 
         streamClosed = []
-        readyMics = None
-        allMics = set()
+        readyTomos = None
+        allTomos = set()
         for coordSet in self.inputCoordinates:
             currentPickTomos, isSetClosed = getReadyTomos(coordSet.get())
             streamClosed.append(isSetClosed)
-            if not readyMics:  # first time
-                readyMics = currentPickTomos
+            if not readyTomos:  # first time
+                readyTomos = currentPickTomos
             else:  # available mics are those ready for all pickers
-                readyMics.intersection_update(currentPickTomos)
-            allMics = allMics.union(currentPickTomos)
+                readyTomos.intersection_update(currentPickTomos)
+            allTomos = allTomos.union(currentPickTomos)
 
         self.streamClosed = all(streamClosed)
         if self.streamClosed:
             # for non streaming do all and in the last iteration of streaming do the rest
-            newTomoIds = allMics.difference(self.checkedTomos)
+            newTomoIds = allTomos.difference(self.checkedTomos)
         else:  # for streaming processing, only go for the ready mics in all pickers
-            newTomoIds = readyMics.difference(self.checkedTomos)
+            newTomoIds = readyTomos.difference(self.checkedTomos)
 
         if newTomoIds:
             self.checkedTomos.update(newTomoIds)

--- a/tomo/protocols/protocol_particle_pick_remove_duplicates.py
+++ b/tomo/protocols/protocol_particle_pick_remove_duplicates.py
@@ -69,7 +69,7 @@ class ProtTomoPickingRemoveDuplicates(ProtTomoConsensusPicking):
         for tomo in tomos:
             stepId = self._insertFunctionStep("removeDuplicatesStep",
                                               tomo.getObjId(),
-                                              tomo.getMicName(),
+                                              tomo.getFileName(),
                                               prerequisites=[])
             deps.append(stepId)
         return deps

--- a/tomo/protocols/protocol_particle_pick_remove_duplicates.py
+++ b/tomo/protocols/protocol_particle_pick_remove_duplicates.py
@@ -1,0 +1,126 @@
+# **************************************************************************
+# *
+# * Authors:    Carlos Oscar Sorzano (coss@cnb.csic.es)
+# *             Tomas Majtner (tmajtner@cnb.csic.es)  -- streaming version
+# *             David Herreros Calero (dherreros@cnb.csic.es) -- Tomo version
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'coss@cnb.csic.es'
+# *
+# **************************************************************************
+"""
+Consensus picking protocol
+"""
+
+import numpy as np
+
+import pyworkflow.protocol.params as params
+from pyworkflow.utils import getFiles, removeBaseExt
+
+from .protocol_particle_pick_consensus import (ProtTomoConsensusPicking,
+                                               consensusWorker, getReadyTomos)
+
+
+class ProtTomoPickingRemoveDuplicates(ProtTomoConsensusPicking):
+    """
+    This protocol removes coordinates that are closer than a given threshold.
+    The remaining coordinate is the average of the previous ones.
+    """
+
+    _label = 'remove duplicates'
+    outputName = 'outputCoordinates'
+    FN_PREFIX = 'purgedCoords_'
+
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputCoordinates', params.PointerParam,
+                      pointerClass='SetOfCoordinates3D',
+                      label="Input coordinates", important=True,
+                      help='Select the set of 3D coordinates to compare')
+        form.addParam('consensusRadius', params.IntParam, default=10,
+                      label="Radius",
+                      help="All coordinates within this radius (in pixels) "
+                           "are presumed to correspond to the same particle")
+
+        # FIXME: It's not using more than one since
+        #         self.stepsExecutionMode = STEPS_SERIAL
+        # form.addParallelSection(threads=4, mpi=0)
+
+#--------------------------- INSERT steps functions ----------------------------
+    def insertNewCoorsSteps(self, tomos):
+        deps = []
+        for tomo in tomos:
+            stepId = self._insertFunctionStep("removeDuplicatesStep",
+                                              tomo.getObjId(),
+                                              tomo.getMicName(),
+                                              prerequisites=[])
+            deps.append(stepId)
+        return deps
+
+    def _checkNewInput(self):
+        # If continue from an stopped run, don't repeat what is done
+        if not self.checkedTomos:
+            for fn in getFiles(self._getExtraPath()):
+                fn = removeBaseExt(fn)
+                if fn.startswith(self.FN_PREFIX):
+                    self.checkedTomos.update([self.getTomoId(fn)])
+                    self.processedTomos.update([self.getTomoId(fn)])
+
+        readyTomos, self.streamClosed = getReadyTomos(self.inputCoordinates.get())
+
+        newTomosIds = readyTomos.difference(self.checkedTomos)
+
+        if newTomosIds:
+            self.checkedTomos.update(newTomosIds)
+
+            inTomos = self.getMainInput().getPrecedents()
+            newTomos = [inTomos[tomoId].clone() for tomoId in newTomosIds]
+
+            fDeps = self.insertNewCoorsSteps(newTomos)
+            outputStep = self._getFirstJoinStep()
+            if outputStep is not None:
+                outputStep.addPrerequisites(*fDeps)
+            self.updateSteps()
+
+    def getMainInput(self):
+        return self.inputCoordinates.get()
+
+    def defineRelations(self, outputSet):
+        self._defineTransformRelation(self.getMainInput(), outputSet)
+
+    def removeDuplicatesStep(self, tomoId, tomoName):
+        print("Removing duplicates for tomogram %d: '%s'"
+              % (tomoId, tomoName))
+
+        coordArray = np.asarray([x.getPosition() for x in
+                                 self.getMainInput().iterCoordinates(tomoId)],
+                                dtype=int)
+
+        consensusWorker([coordArray], 1, self.consensusRadius.get(),
+                        self._getTmpPath('%s%s.txt' % (self.FN_PREFIX, tomoId)))
+
+        self.processedTomos.update([tomoId])
+
+    def _validate(self):
+        errors = []
+        return errors
+
+    def _summary(self):
+        return ["Radius = %d" % self.consensusRadius]

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -1002,6 +1002,66 @@ class TestTomoAssignTomo2Subtomo(BaseTest):
         self.assertFalse(tomo2subtomo.outputSubtomograms.getFirstItem().getVolName())
         return tomo2subtomo
 
+class TestTomoPickingConsenus(BaseTest):
+    """This class check if the consensus of a SetOfCoordinates3D works properly."""
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dataset = DataSet.getDataSet('tomo-em')
+        cls.tomogram_1 = cls.dataset.getFile('tomo1')
+        cls.tomogram_2 = cls.dataset.getFile('tomo2')
+
+    def _importSetOfCoordinates(self, tomoFile, pattern):
+        protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
+                                              filesPath=tomoFile,
+                                              samplingRate=5,
+                                              objLabel=pwutils.removeBaseExt(tomoFile))
+
+        self.launchProtocol(protImportTomogram)
+
+        output = getattr(protImportTomogram, 'outputTomograms', None)
+
+        self.assertIsNotNone(output,
+                             "There was a problem with tomogram output")
+
+        protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
+                                  objLabel='Coordinates ' + pwutils.removeBaseExt(tomoFile),
+                                  auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_AUTO,
+                                  filesPath=self.dataset.getPath(),
+                                  importTomograms=protImportTomogram.outputTomograms,
+                                  filesPattern=pattern, boxSize=32,
+                                  samplingRate=5)
+        self.launchProtocol(protImportCoordinates3d)
+
+        return getattr(protImportCoordinates3d, 'outputCoordinates', None)
+
+    def _runTomoPickingConsensus(self, coordinates, consensus, mode):
+        choices_mode = ['>=', '=']
+        choices_consensus = {-1: 'AND', 1: 'OR'}
+        protPickingConsensus = self.newProtocol(tomo.protocols.ProtTomoConsensusPicking,
+                                                inputCoordinates=coordinates,
+                                                consensus=consensus,
+                                                mode=mode,
+                                                objLabel='Consenus - ' + choices_consensus[consensus]
+                                                            + ' - ' + choices_mode[mode])
+        self.launchProtocol(protPickingConsensus)
+        return protPickingConsensus
+
+    def test_picking_consenus(self):
+        coords = []
+        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
+        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
+        protConsensus = self._runTomoPickingConsensus(coords, -1, 0)
+        output = getattr(protConsensus, 'consensusCoordinates', None)
+        self.assertTrue(output,
+                             "There was a problem with consenus output")
+        self.assertTrue(output.getSize() == 5)
+        self.assertTrue(output.getBoxSize() == 32)
+        self.assertTrue(output.getSamplingRate() == 5)
+
+        return output
+
 
 if __name__ == 'main':
     pass

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -1003,7 +1003,7 @@ class TestTomoAssignTomo2Subtomo(BaseTest):
         return tomo2subtomo
 
 class TestTomoPickingConsenus(BaseTest):
-    """This class check if the consensus of a SetOfCoordinates3D works properly."""
+    """This class check if the consensus from a series of SetOfCoordinates3D works properly."""
 
     @classmethod
     def setUpClass(cls):
@@ -1054,6 +1054,70 @@ class TestTomoPickingConsenus(BaseTest):
         coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
         protConsensus = self._runTomoPickingConsensus(coords, -1, 0)
         output = getattr(protConsensus, 'consensusCoordinates', None)
+        self.assertTrue(output,
+                             "There was a problem with consenus output")
+        self.assertTrue(output.getSize() == 5)
+        self.assertTrue(output.getBoxSize() == 32)
+        self.assertTrue(output.getSamplingRate() == 5)
+
+        return output
+
+class TestTomoPickingRemoveDuplicates(BaseTest):
+    """This class check if the removal of duplicates from a series
+     of SetOfCoordinates3D works properly."""
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dataset = DataSet.getDataSet('tomo-em')
+        cls.tomogram_1 = cls.dataset.getFile('tomo1')
+        cls.tomogram_2 = cls.dataset.getFile('tomo2')
+
+    def _importSetOfCoordinates(self, tomoFile, pattern):
+        protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
+                                              filesPath=tomoFile,
+                                              samplingRate=5,
+                                              objLabel=pwutils.removeBaseExt(tomoFile))
+
+        self.launchProtocol(protImportTomogram)
+
+        output = getattr(protImportTomogram, 'outputTomograms', None)
+
+        self.assertIsNotNone(output,
+                             "There was a problem with tomogram output")
+
+        protImportCoordinates3d = self.newProtocol(tomo.protocols.ProtImportCoordinates3D,
+                                  objLabel='Coordinates ' + pwutils.removeBaseExt(tomoFile),
+                                  auto=tomo.protocols.ProtImportCoordinates3D.IMPORT_FROM_AUTO,
+                                  filesPath=self.dataset.getPath(),
+                                  importTomograms=protImportTomogram.outputTomograms,
+                                  filesPattern=pattern, boxSize=32,
+                                  samplingRate=5)
+        self.launchProtocol(protImportCoordinates3d)
+
+        return getattr(protImportCoordinates3d, 'outputCoordinates', None)
+
+    def _joinSets(self, sets):
+        protJoinSets = self.newProtocol(emprot.ProtUnionSet,
+                                        inputSets=sets,
+                                        objLabel='Duplicated Coordinates 3D')
+        self.launchProtocol(protJoinSets)
+        return getattr(protJoinSets, 'outputSet', None)
+
+    def _runTomoPickingRemoveDuplicates(self, coordinates):
+        protPickingConsensus = self.newProtocol(tomo.protocols.ProtTomoPickingRemoveDuplicates,
+                                                inputCoordinates=coordinates,
+                                                objLabel='Remove Duplicates')
+        self.launchProtocol(protPickingConsensus)
+        return protPickingConsensus
+
+    def test_picking_consenus(self):
+        coords = []
+        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
+        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
+        all_coords = self._joinSets(coords)
+        protRemoveDuplicates = self._runTomoPickingRemoveDuplicates(all_coords)
+        output = getattr(protRemoveDuplicates, 'outputCoordinates', None)
         self.assertTrue(output,
                              "There was a problem with consenus output")
         self.assertTrue(output.getSize() == 5)

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -1052,6 +1052,8 @@ class TestTomoPickingConsenus(BaseTest):
         coords = []
         coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
         coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
+
+        # AND + >=
         protConsensus = self._runTomoPickingConsensus(coords, -1, 0)
         output = getattr(protConsensus, 'consensusCoordinates', None)
         self.assertTrue(output,
@@ -1059,6 +1061,33 @@ class TestTomoPickingConsenus(BaseTest):
         self.assertTrue(output.getSize() == 5)
         self.assertTrue(output.getBoxSize() == 32)
         self.assertTrue(output.getSamplingRate() == 5)
+
+        # AND + =
+        # protConsensus = self._runTomoPickingConsensus(coords, -1, 1)
+        # output = getattr(protConsensus, 'consensusCoordinates', None)
+        # self.assertTrue(output,
+        #                      "There was a problem with consenus output")
+        # self.assertTrue(output.getSize() == 5)
+        # self.assertTrue(output.getBoxSize() == 32)
+        # self.assertTrue(output.getSamplingRate() == 5)
+
+        # OR + >=
+        # protConsensus = self._runTomoPickingConsensus(coords, 1, 0)
+        # output = getattr(protConsensus, 'consensusCoordinates', None)
+        # self.assertTrue(output,
+        #                      "There was a problem with consenus output")
+        # self.assertTrue(output.getSize() == 5)
+        # self.assertTrue(output.getBoxSize() == 32)
+        # self.assertTrue(output.getSamplingRate() == 5)
+
+        # OR + =
+        # protConsensus = self._runTomoPickingConsensus(coords, 1, 1)
+        # output = getattr(protConsensus, 'consensusCoordinates', None)
+        # self.assertTrue(output,
+        #                      "There was a problem with consenus output")
+        # self.assertTrue(output.getSize() == 5)
+        # self.assertTrue(output.getBoxSize() == 32)
+        # self.assertTrue(output.getSamplingRate() == 5)
 
         return output
 


### PR DESCRIPTION
Port of protocols `protocol_particle_pick_remove_duplicates` and `protocol_particle_pick_consensus` from Xmipp to work with Tomo objects `SetOfCoordinates3D` and `Coordinate3D`.

Together with the protocols a couple of tests have been also included (`TestTomoPickingConsenus` and `TestTomoPickingRemoveDuplicates`).