### PR TITLE
Consensus improved tests and normal adjustment

### DIFF
--- a/tomo/protocols/protocol_particle_pick_consensus.py
+++ b/tomo/protocols/protocol_particle_pick_consensus.py
@@ -206,7 +206,10 @@ class ProtTomoConsensusPicking(ProtTomoPicking):
                         tomograms = self.getMainInput().getPrecedents()
                         newCoord.setVolume(tomograms[self.getTomoId(fnTmp)])
                         newCoord.setPosition(coord[0], coord[1], coord[2])
-                        newCoord.setMatrix(self.inputCoordinates[coords_ids[idx, 0]].get()[int(coords_ids[idx, 1])].getMatrix())
+                        if isinstance(self.inputCoordinates, list):
+                            newCoord.setMatrix(self.inputCoordinates[coords_ids[idx, 0]].get()[int(coords_ids[idx, 1])].getMatrix())
+                        else:
+                            newCoord.setMatrix(self.getMainInput()[int(coords_ids[idx, 1])].getMatrix())
                         outSet.append(newCoord)
 
             firstTime = not self.hasAttribute(self.outputName)
@@ -233,12 +236,12 @@ class ProtTomoConsensusPicking(ProtTomoPicking):
         else:
             outputSet = SetClass(filename=setFile)
             outputSet.setStreamState(outputSet.STREAM_OPEN)
-            outputSet.setBoxSize(self.getMainInput().getBoxSize())
-            outputSet.setSamplingRate(self.getMainInput().getSamplingRate())
 
         #inMicsPointer = Pointer(self.getMapper().getParent(
         #                                    self.getMainInput().getMicrographs()),
         #                                    extended='outputMicrographs')
+        outputSet.setBoxSize(self.getMainInput().getBoxSize())
+        outputSet.setSamplingRate(self.getMainInput().getSamplingRate())
         inTomosPointer = Pointer(self.getMainInput().getPrecedents())
         outputSet.setPrecedents(inTomosPointer)
 

--- a/tomo/protocols/protocol_particle_pick_remove_duplicates.py
+++ b/tomo/protocols/protocol_particle_pick_remove_duplicates.py
@@ -112,11 +112,8 @@ class ProtTomoPickingRemoveDuplicates(ProtTomoConsensusPicking):
         coordArray = np.asarray([x.getPosition() for x in
                                  self.getMainInput().iterCoordinates(tomoId)],
                                  dtype=int)
-        idArray = np.asarray([x.getObjId() for x in
-                              self.getMainInput().iterCoordinates(tomoId)],
-                              dtype=int)
 
-        consensusWorker([coordArray], [idArray], 1, self.consensusRadius.get(),
+        consensusWorker([coordArray], 1, self.consensusRadius.get(),
                         self._getTmpPath('%s%s.txt' % (self.FN_PREFIX, tomoId)))
 
         self.processedTomos.update([tomoId])

--- a/tomo/protocols/protocol_particle_pick_remove_duplicates.py
+++ b/tomo/protocols/protocol_particle_pick_remove_duplicates.py
@@ -111,9 +111,12 @@ class ProtTomoPickingRemoveDuplicates(ProtTomoConsensusPicking):
 
         coordArray = np.asarray([x.getPosition() for x in
                                  self.getMainInput().iterCoordinates(tomoId)],
-                                dtype=int)
+                                 dtype=int)
+        idArray = np.asarray([x.getObjId() for x in
+                              self.getMainInput().iterCoordinates(tomoId)],
+                              dtype=int)
 
-        consensusWorker([coordArray], 1, self.consensusRadius.get(),
+        consensusWorker([coordArray], [idArray], 1, self.consensusRadius.get(),
                         self._getTmpPath('%s%s.txt' % (self.FN_PREFIX, tomoId)))
 
         self.processedTomos.update([tomoId])

--- a/tomo/tests/__init__.py
+++ b/tomo/tests/__init__.py
@@ -36,3 +36,9 @@ DataSet(name='tomo-em', folder='tomo-em',
                'etomo': 'tutorialData',
                'empiar': 'EMPIAR-10164'
         })
+
+DataSet(name='reliontomo', folder='reliontomo',
+        files={
+               'tomo1': '64K_defocus_m2_tomo_10_bin1_WBP_CatBinned1.mrc',
+               'tomo2': '64K_defocus_m2_tomo_12_bin1_WBP_CatBinned1.mrc',
+        })

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -1008,14 +1008,14 @@ class TestTomoPickingConsenus(BaseTest):
     @classmethod
     def setUpClass(cls):
         setupTestProject(cls)
-        cls.dataset = DataSet.getDataSet('tomo-em')
+        cls.dataset = DataSet.getDataSet('reliontomo')
         cls.tomogram_1 = cls.dataset.getFile('tomo1')
         cls.tomogram_2 = cls.dataset.getFile('tomo2')
 
     def _importSetOfCoordinates(self, tomoFile, pattern):
         protImportTomogram = self.newProtocol(tomo.protocols.ProtImportTomograms,
                                               filesPath=tomoFile,
-                                              samplingRate=5,
+                                              samplingRate=1,
                                               objLabel=pwutils.removeBaseExt(tomoFile))
 
         self.launchProtocol(protImportTomogram)
@@ -1031,7 +1031,7 @@ class TestTomoPickingConsenus(BaseTest):
                                   filesPath=self.dataset.getPath(),
                                   importTomograms=protImportTomogram.outputTomograms,
                                   filesPattern=pattern, boxSize=32,
-                                  samplingRate=5)
+                                  samplingRate=1)
         self.launchProtocol(protImportCoordinates3d)
 
         return getattr(protImportCoordinates3d, 'outputCoordinates', None)
@@ -1043,51 +1043,52 @@ class TestTomoPickingConsenus(BaseTest):
                                                 inputCoordinates=coordinates,
                                                 consensus=consensus,
                                                 mode=mode,
+                                                consensusRadius=100,
                                                 objLabel='Consenus - ' + choices_consensus[consensus]
-                                                            + ' - ' + choices_mode[mode])
+                                                          + ' - ' + choices_mode[mode])
         self.launchProtocol(protPickingConsensus)
         return protPickingConsensus
 
     def test_picking_consenus(self):
         coords = []
-        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
-        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.txt'))
+        coords.append(self._importSetOfCoordinates(self.tomogram_1, '*.tbl'))
+        coords.append(self._importSetOfCoordinates(self.tomogram_2, '*.tbl'))
 
         # AND + >=
         protConsensus = self._runTomoPickingConsensus(coords, -1, 0)
         output = getattr(protConsensus, 'consensusCoordinates', None)
         self.assertTrue(output,
                              "There was a problem with consenus output")
-        self.assertTrue(output.getSize() == 5)
+        self.assertTrue(output.getSize() == 20)
         self.assertTrue(output.getBoxSize() == 32)
-        self.assertTrue(output.getSamplingRate() == 5)
+        self.assertTrue(output.getSamplingRate() == 1)
 
         # AND + =
-        # protConsensus = self._runTomoPickingConsensus(coords, -1, 1)
-        # output = getattr(protConsensus, 'consensusCoordinates', None)
-        # self.assertTrue(output,
-        #                      "There was a problem with consenus output")
-        # self.assertTrue(output.getSize() == 5)
-        # self.assertTrue(output.getBoxSize() == 32)
-        # self.assertTrue(output.getSamplingRate() == 5)
+        protConsensus = self._runTomoPickingConsensus(coords, -1, 1)
+        output = getattr(protConsensus, 'consensusCoordinates', None)
+        self.assertTrue(output,
+                             "There was a problem with consenus output")
+        self.assertTrue(output.getSize() == 3)
+        self.assertTrue(output.getBoxSize() == 32)
+        self.assertTrue(output.getSamplingRate() == 1)
 
         # OR + >=
-        # protConsensus = self._runTomoPickingConsensus(coords, 1, 0)
-        # output = getattr(protConsensus, 'consensusCoordinates', None)
-        # self.assertTrue(output,
-        #                      "There was a problem with consenus output")
-        # self.assertTrue(output.getSize() == 5)
-        # self.assertTrue(output.getBoxSize() == 32)
-        # self.assertTrue(output.getSamplingRate() == 5)
+        protConsensus = self._runTomoPickingConsensus(coords, 1, 0)
+        output = getattr(protConsensus, 'consensusCoordinates', None)
+        self.assertTrue(output,
+                             "There was a problem with consenus output")
+        self.assertTrue(output.getSize() == 83)
+        self.assertTrue(output.getBoxSize() == 32)
+        self.assertTrue(output.getSamplingRate() == 1)
 
         # OR + =
-        # protConsensus = self._runTomoPickingConsensus(coords, 1, 1)
-        # output = getattr(protConsensus, 'consensusCoordinates', None)
-        # self.assertTrue(output,
-        #                      "There was a problem with consenus output")
-        # self.assertTrue(output.getSize() == 5)
-        # self.assertTrue(output.getBoxSize() == 32)
-        # self.assertTrue(output.getSamplingRate() == 5)
+        protConsensus = self._runTomoPickingConsensus(coords, 1, 1)
+        output = getattr(protConsensus, 'consensusCoordinates', None)
+        self.assertTrue(output,
+                             "There was a problem with consenus output")
+        self.assertTrue(output.getSize() == 63)
+        self.assertTrue(output.getBoxSize() == 32)
+        self.assertTrue(output.getSamplingRate() == 1)
 
         return output
 

--- a/tomo/tests/test_tomo_base.py
+++ b/tomo/tests/test_tomo_base.py
@@ -1036,14 +1036,14 @@ class TestTomoPickingConsenus(BaseTest):
 
         return getattr(protImportCoordinates3d, 'outputCoordinates', None)
 
-    def _runTomoPickingConsensus(self, coordinates, consensus, mode):
+    def _runTomoPickingConsensus(self, coordinates, consensus, mode, radius=100):
         choices_mode = ['>=', '=']
         choices_consensus = {-1: 'AND', 1: 'OR'}
         protPickingConsensus = self.newProtocol(tomo.protocols.ProtTomoConsensusPicking,
                                                 inputCoordinates=coordinates,
                                                 consensus=consensus,
                                                 mode=mode,
-                                                consensusRadius=100,
+                                                consensusRadius=radius,
                                                 objLabel='Consenus - ' + choices_consensus[consensus]
                                                           + ' - ' + choices_mode[mode])
         self.launchProtocol(protPickingConsensus)
@@ -1064,11 +1064,11 @@ class TestTomoPickingConsenus(BaseTest):
         self.assertTrue(output.getSamplingRate() == 1)
 
         # AND + =
-        protConsensus = self._runTomoPickingConsensus(coords, -1, 1)
+        protConsensus = self._runTomoPickingConsensus(coords, -1, 1, radius=50)
         output = getattr(protConsensus, 'consensusCoordinates', None)
         self.assertTrue(output,
                              "There was a problem with consenus output")
-        self.assertTrue(output.getSize() == 3)
+        self.assertTrue(output.getSize() == 5)
         self.assertTrue(output.getBoxSize() == 32)
         self.assertTrue(output.getSamplingRate() == 1)
 


### PR DESCRIPTION
- Test for `protocol_particle_pick_consensus` has been extended to cover the different combination of the parameters.

- New functionality added to `protocol_particle_pick_consensus` and `protocol_particle_pick_remove_duplicates`. After finding new coordinates, a triangulation is generated to readjust the normals and the transformation matrices to the new coordinates. This functionality requires the changes from [#325](https://github.com/I2PC/scipion-em-xmipp/pull/325) to work properly. New dependency (pyvista) added to scipion-em-xmipp is also needed.
