### PR TITLE
Load Vesicles from Tomogram on demand

### DIFF
--- a/tomo/utils.py
+++ b/tomo/utils.py
@@ -50,7 +50,9 @@ def normalFromMatrix(transformation):
 
 def initDictVesicles(coordinates):
     tomos = coordinates.getPrecedents()
-    tomoNames = [pwutils.removeBaseExt(tomo.getFileName()) for tomo in tomos]
+    volIds = coordinates.aggregate(["MAX"], "_volId", ["_volId"])
+    volIds = [d['_volId'] for d in volIds]
+    tomoNames = [pwutils.removeBaseExt(tomos[volId].getFileName()) for volId in volIds]
     dictVesicles = {tomoField: {'vesicles': [], 'normals': [], 'ids': []}
                      for tomoField in tomoNames}
     return dictVesicles, tomoNames

--- a/tomo/utils.py
+++ b/tomo/utils.py
@@ -59,19 +59,20 @@ def extractVesicles(coordinates, dictVesicles, tomoName):
     tomoId = list(dictVesicles.keys()).index(tomoName) + 1
     groupIds = coordinates.aggregate(["MAX"], "_volId", ["_groupId", "_volId"])
     groupIds = [d['_groupId'] for d in groupIds if d['_volId'] == tomoId]
-    for idv in groupIds:
-        vesicle = []
-        normals = []
-        ids = []
-        for coord in coordinates.iterCoordinates(volume=coordinates.getPrecedents()[tomoId]):
-            if coord.getGroupId() == idv:
-                vesicle.append(coord.getPosition())
-                trMat = coord.getMatrix()
-                normals.append(normalFromMatrix(trMat))
-                ids.append(coord.getObjId())
-        dictVesicles[tomoName]['vesicles'].append(np.asarray(vesicle))
-        dictVesicles[tomoName]['normals'].append(np.asarray(normals))
-        dictVesicles[tomoName]['ids'].append(np.asarray(ids))
+    if not dictVesicles[tomoName]['vesicles']:
+        for idv in groupIds:
+            vesicle = []
+            normals = []
+            ids = []
+            for coord in coordinates.iterCoordinates(volume=coordinates.getPrecedents()[tomoId]):
+                if coord.getGroupId() == idv:
+                    vesicle.append(coord.getPosition())
+                    trMat = coord.getMatrix()
+                    normals.append(normalFromMatrix(trMat))
+                    ids.append(coord.getObjId())
+            dictVesicles[tomoName]['vesicles'].append(np.asarray(vesicle))
+            dictVesicles[tomoName]['normals'].append(np.asarray(normals))
+            dictVesicles[tomoName]['ids'].append(np.asarray(ids))
     return dictVesicles
 
 

--- a/tomo/viewers/viewers_data.py
+++ b/tomo/viewers/viewers_data.py
@@ -78,7 +78,7 @@ class TomoDataViewer(pwviewer.Viewer):
             meshList = []
             for item in obj.iterItems():
                 mesh = item.clone()
-                mesh.setVolume(item.getVolume())
+                mesh.setVolume(item.getVolume().clone())
                 meshList.append(mesh)
 
             tomoProvider = MeshesTreeProvider(meshList)


### PR DESCRIPTION
The method `extractVesicles` from `utils.py` has been modified to load only those vesicles blonging to a specific Tomogram. Toghether with this functionality, a new method (`initDictVesicles`) has been added to initialize the dictionary to be used with the new version of `extractVesicles`.

The PR includes also a small fix for the viewer of `SetOfMeshes`.