### PR TITLE
Warning Method and Checks

### DIFF
--- a/tomo/protocols/protocol_import_coordinates.py
+++ b/tomo/protocols/protocol_import_coordinates.py
@@ -161,10 +161,25 @@ class ProtImportCoordinates3D(ProtTomoImportFiles):
         coordFiles = [pwutils.removeBaseExt(file) for file, _ in self.iterFiles()]
         numberMatches = len(set(tomoFiles) & set(coordFiles))
         if numberMatches < max(len(tomoFiles), len(coordFiles)):
-            warnings.append("Warning: Couldn't find a correspondence between all cordinate and tomogram files. "
-                            "In case of unexpected behaviour, check that the filename of the corresponding "
-                            "tomogram and coordinate files are equal and that all tomogram files have an associated "
-                            "coordinate file.")
+            warnings.append("Couldn't find a correspondence between all cordinate and tomogram files. "
+                            "Association is performed in terms of the file name of the Tomograms and the coordinates. "
+                            "(without the extension). For example, if a Tomogram file is named Tomo_1.mrc, the coordinate "
+                            "file to be associated to it should be named Tomo_1.ext (being 'ext' any valid extension "
+                            "- '.txt', '.tbl', '.json').\n")
+            mismatches_coords = set(coordFiles).difference(tomoFiles)
+            if mismatches_coords:
+                warnings.append("The following coordinate files will not be associated to any Tomogram "
+                                "(name without extension):")
+                for file in mismatches_coords:
+                    warnings.append("\t%s" % file)
+                warnings.append("\n")
+            mismatches_tomos = set(tomoFiles).difference(coordFiles)
+            if mismatches_tomos:
+                warnings.append("The following Tomogram files will not be associated to any coordinates "
+                                "(name without extension):")
+                for file in mismatches_tomos:
+                    warnings.append("\t%s" % file)
+                warnings.append("\n")
         return warnings
 
     # ------------------ UTILS functions --------------------------------------

--- a/tomo/protocols/protocol_import_coordinates.py
+++ b/tomo/protocols/protocol_import_coordinates.py
@@ -151,13 +151,19 @@ class ProtImportCoordinates3D(ProtTomoImportFiles):
                 errors.append("Cannot relate tomogram and coordinate files. In order to stablish a "
                               "relation, the filename of the corresponding tomogram and coordinate "
                               "files must be equal.")
-            else:
-                print("Warning: Couldn't find a correspondence between all cordinate and tomogram files. "
-                      "In case of unexpected behaviour, check that the filename of the corresponding "
-                      "tomogram and coordinate files are equal and that all tomogram files have an associated "
-                      "coordinate file.")
-
         return errors
+
+    def _warnings(self):
+        warnings = []
+        tomoFiles = [pwutils.removeBaseExt(file) for file in self.importTomograms.get().getFiles()]
+        coordFiles = [pwutils.removeBaseExt(file) for file, _ in self.iterFiles()]
+        numberMatches = len(set(tomoFiles) & set(coordFiles))
+        if numberMatches < max(len(tomoFiles), len(coordFiles)):
+            warnings.append("Warning: Couldn't find a correspondence between all cordinate and tomogram files. "
+                            "In case of unexpected behaviour, check that the filename of the corresponding "
+                            "tomogram and coordinate files are equal and that all tomogram files have an associated "
+                            "coordinate file.")
+        return warnings
 
     # ------------------ UTILS functions --------------------------------------
     def getImportFrom(self):

--- a/tomo/protocols/protocol_import_coordinates.py
+++ b/tomo/protocols/protocol_import_coordinates.py
@@ -141,7 +141,9 @@ class ProtImportCoordinates3D(ProtTomoImportFiles):
 
     def _validate(self):
         errors = []
-        if not list(self.iterFiles()):
+        try:
+            next(self.iterFiles())
+        except StopIteration:
             errors.append('No files matching the pattern %s were found.' % self.getPattern())
         else:
             tomoFiles = [pwutils.removeBaseExt(file) for file in self.importTomograms.get().getFiles()]

--- a/tomo/protocols/protocol_import_subtomograms.py
+++ b/tomo/protocols/protocol_import_subtomograms.py
@@ -189,6 +189,8 @@ class ProtImportSubTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
 
     def _validate(self):
         errors = []
-        if not list(self.iterFiles()):
+        try:
+            next(self.iterFiles())
+        except StopIteration:
             errors.append('No files matching the pattern %s were found.' % self.getPattern())
         return errors

--- a/tomo/protocols/protocol_import_tomograms.py
+++ b/tomo/protocols/protocol_import_tomograms.py
@@ -167,7 +167,9 @@ class ProtImportTomograms(ProtTomoImportFiles, ProtTomoImportAcquisition):
 
     def _validate(self):
         errors = []
-        if not list(self.iterFiles()):
+        try:
+            next(self.iterFiles())
+        except StopIteration:
             errors.append('No files matching the pattern %s were found.' % self.getPattern())
         return errors
 


### PR DESCRIPTION
- Moved warning message (`protocol_import_coordinates`) to _warning method to avoid prints in the console.

- Modified `protocol_import_coordinates`, `protocol_import_subtomograms` and `protocol_import_tomograms` to avoid loading all input files when checking the input path pattern.