### PR TITLE
Viewer temporary files moved to extra

### DIFF
--- a/tomo/viewers/viewer_tomograms.py
+++ b/tomo/viewers/viewer_tomograms.py
@@ -117,15 +117,15 @@ class ViewerProtImportTomograms(EmProtocolViewer):
         sampling = setOfObjects.getSamplingRate()
         return sampling, setOfObjects
 
-    def _getTmpFolder(self, fileName):
+    def _getExtraFolder(self, fileName):
         if self._sourceIsOutput():
             return os.path.join(tempfile.mkdtemp(), fileName)
         else:
-            return self.protocol._getTmpPath(fileName)
+            return self.protocol._getExtraPath(fileName)
 
     def _showTomogramsChimera(self):
         """ Create a chimera script to visualize selected tomograms. """
-        tmpFileNameCMD = self._getTmpFolder("chimera.cxc")
+        tmpFileNameCMD = self._getExtraFolder("chimera.cxc")
         f = open(tmpFileNameCMD, "w")
         sampling, _setOfObjects = self._getSetAndSampling()
         count = 1  # first model in chimera is a tomogram
@@ -138,7 +138,7 @@ class ViewerProtImportTomograms(EmProtocolViewer):
             # be in the center of the window
 
             dim = _setOfObjects.getDim()[0]
-            tmpFileNameBILD = os.path.abspath(self._getTmpFolder("axis.bild"))
+            tmpFileNameBILD = os.path.abspath(self._getExtraFolder("axis.bild"))
             viewers.viewer_chimera.Chimera.createCoordinateAxisFile(dim,
                                                                     bildFileName=tmpFileNameBILD,
                                                                     sampling=sampling)

--- a/tomo/viewers/viewers_data.py
+++ b/tomo/viewers/viewers_data.py
@@ -83,7 +83,7 @@ class TomoDataViewer(pwviewer.Viewer):
 
             tomoProvider = MeshesTreeProvider(meshList)
 
-            path = self.protocol._getTmpPath()
+            path = self.protocol._getExtraPath()
             setView = TomogramsDialog(self._tkRoot, True, provider=tomoProvider, path=path)
 
         return views

--- a/tomo/viewers/views_tkinter_tree.py
+++ b/tomo/viewers/views_tkinter_tree.py
@@ -332,11 +332,14 @@ class TomogramsDialog(ToolbarListDialog):
             self.after(1000, self.refresh_gui_viewer)
         else:
             pwutils.cleanPath(os.path.join(self.path, 'mesh.txt'))
+            pwutils.cleanPath(self.macroPath)
 
     def refresh_gui(self):
         self.tree.update()
         if self.proc.isAlive():
             self.after(1000, self.refresh_gui)
+        else:
+            pwutils.cleanPath(self.macroPath)
 
     def doubleClickOnTomogram(self, e=None):
         self.tomo = e
@@ -352,7 +355,7 @@ class TomogramsDialog(ToolbarListDialog):
         self.after(1000, self.refresh_gui_viewer)
 
     def lanchIJForTomogram(self, path, tomogram):
-        macroPath = os.path.join(conf.Config.SCIPION_TMP, "AutoSave_ROI.ijm")
+        self.macroPath = os.path.join(conf.Config.SCIPION_TMP, "AutoSave_ROI.ijm")
         tomogramFile = tomogram.getFileName()
         tomogramName = os.path.basename(tomogramFile)
 
@@ -502,11 +505,11 @@ class TomogramsDialog(ToolbarListDialog):
     return groupEnd;
     }
     """ % (os.path.join(path, ''), os.path.splitext(tomogramName)[0])
-        macroFid = open(macroPath, 'w')
+        macroFid = open(self.macroPath, 'w')
         macroFid.write(macro)
         macroFid.close()
 
-        args = "-i %s -macro %s" % (tomogramFile, macroPath)
+        args = "-i %s -macro %s" % (tomogramFile, self.macroPath)
         viewParams = {showj.ZOOM: 50}
         for key, value in viewParams.items():
             args = "%s --%s %s" % (args, key, value)
@@ -516,7 +519,7 @@ class TomogramsDialog(ToolbarListDialog):
         runJavaIJapp(4, app, args).wait()
 
     def lanchIJForViewing(self, path, tomogram):
-        macroPath = os.path.join(conf.Config.SCIPION_TMP, "View_ROI.ijm")
+        self.macroPath = os.path.join(conf.Config.SCIPION_TMP, "View_ROI.ijm")
         tomogramFile = tomogram.getFileName()
         tomogramName = os.path.basename(tomogramFile)
 
@@ -581,11 +584,11 @@ class TomogramsDialog(ToolbarListDialog):
     return groups;
     }
     """ % (os.path.join(path, ''), os.path.splitext(tomogramName)[0], meshFile)
-        macroFid = open(macroPath, 'w')
+        macroFid = open(self.macroPath, 'w')
         macroFid.write(macro)
         macroFid.close()
 
-        args = "-i %s -macro %s" % (tomogramFile, macroPath)
+        args = "-i %s -macro %s" % (tomogramFile, self.macroPath)
         viewParams = {showj.ZOOM: 50}
         for key, value in viewParams.items():
             args = "%s --%s %s" % (args, key, value)


### PR DESCRIPTION
Move viewer temporary files to extra path to avoid errors due to missing tmp path