### PR TITLE
Jj ts import fixes

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -115,7 +115,6 @@ class TiltSeriesBase(data.SetOfImages):
         # TiltSeries will always be used inside a SetOfTiltSeries
         # so, let's do no store the mapper path by default
         self._mapperPath.setStore(False)
-
         self._origin = None
 
     def getTsId(self):
@@ -562,13 +561,15 @@ class TiltSeriesDict:
 
 
 class TomoAcquisition(data.Acquisition):
-    def __init__(self, angleMin=None, angleMax=None, step=None, angleAxis1=None, angleAxis2=None, **kwargs):
+    def __init__(self, angleMin=None, angleMax=None, step=None, angleAxis1=None,
+                 angleAxis2=None, accumDose=None, **kwargs):
         data.Acquisition.__init__(self, **kwargs)
         self._angleMin = pwobj.Float(angleMin)
         self._angleMax = pwobj.Float(angleMax)
         self._step = pwobj.Float(step)
         self._angleAxis1 = pwobj.Float(angleAxis1)
         self._angleAxis2 = pwobj.Float(angleAxis2)
+        self._accumDose = pwobj.Float(accumDose)
 
     def getAngleMax(self):
         return self._angleMax.get()
@@ -599,6 +600,12 @@ class TomoAcquisition(data.Acquisition):
 
     def setAngleAxis2(self, value):
         self._angleAxis2.set(value)
+
+    def getAccumDose(self):
+        return self._accumDose.get()
+
+    def setAccumDose(self, value):
+        self._accumDose.set(value)
 
 
 class Tomogram(data.Volume):

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -929,10 +929,12 @@ class Coordinate3D(data.EMObject):
         (referred to the center of the Tomogram or other origin specified by the user)
         to the bottom left corner of the Tomogram
         """
+        vol = self.getVolume()
+        if not vol:
+            raise Exception("3D coordinate must be referred to a volume to get its origin.")
         if angstrom:
-            return self.getVolume().getShiftsFromOrigin()
+            return vol.getShiftsFromOrigin()
         else:
-            vol = self.getVolume()
             sr = vol.getSamplingRate()
             origin = vol.getShiftsFromOrigin()
             return int(origin[0] / sr), int(origin[1] / sr), int(origin[2] / sr)

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -116,6 +116,7 @@ class TiltSeriesBase(data.SetOfImages):
         # so, let's do no store the mapper path by default
         self._mapperPath.setStore(False)
         self._origin = None
+        self._acquisition = TomoAcquisition()
 
     def getTsId(self):
         """ Get unique TiltSerie ID, usually retrieved from the
@@ -274,6 +275,7 @@ class SetOfTiltSeriesBase(data.SetOfImages):
     def __init__(self, **kwargs):
         data.SetOfImages.__init__(self, **kwargs)
         self._anglesCount = Integer()
+        self._acquisition = TomoAcquisition()
 
     def copyInfo(self, other):
         """ Copy information (sampling rate and ctf)

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -115,8 +115,8 @@ class TiltSeriesBase(data.SetOfImages):
         # TiltSeries will always be used inside a SetOfTiltSeries
         # so, let's do no store the mapper path by default
         self._mapperPath.setStore(False)
-        self._origin = None
         self._acquisition = TomoAcquisition()
+        self._origin = Transform()
 
     def getTsId(self):
         """ Get unique TiltSerie ID, usually retrieved from the

--- a/tomo/protocols/protocol_ts_correct_motion.py
+++ b/tomo/protocols/protocol_ts_correct_motion.py
@@ -240,19 +240,19 @@ class ProtTsCorrectMotion(ProtTsProcess):
                 self.outputSetEven.enableAppend()
             else:
                 self.outputSetEven = SetOfTiltSeries.create(self._getPath(), template=template, suffix=EVEN)
-                self.outputSetEven.setAcquisition(acq)
                 self.outputSetEven.setSamplingRate(sRate)
             # Odd
             if self.outputSetOdd:
                 self.outputSetOdd.enableAppend()
             else:
                 self.outputSetOdd = SetOfTiltSeries.create(self._getPath(), template=template, suffix=ODD)
-                self.outputSetOdd.setAcquisition(acq)
                 self.outputSetOdd.setSamplingRate(sRate)
 
             tsClass = self.outputSetEven.ITEM_TYPE
             tsObjEven = tsClass(tsId=tsId)
             tsObjOdd = tsClass(tsId=tsId)
+            tsObjEven.setAcquisition(ts.getAcquisition())
+            tsObjOdd.setAcquisition(ts.getAcquisition())
             self.outputSetEven.append(tsObjEven)
             self.outputSetOdd.append(tsObjOdd)
 

--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -288,6 +288,7 @@ class ProtImportTsBase(ProtImport, ProtTomoBase):
 
                 if self.MDOC_DATA_SOURCE:
                     accumDoseList = self.accumDoses[ts]
+                    tsObj.getAcquisition().setAccumDose(accumDoseList[-1])
                     incomingDoseList = self.incomingDose[ts]
                     counter = 0
 

--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -333,8 +333,9 @@ class ProtImportTsBase(ProtImport, ProtTomoBase):
                 for ti in tiltSeriesObjList:
                     tsObj.append(ti)
 
-                origin.setShifts(-tsObj.getFirstItem().getXDim() / 2 * samplingRate,
-                                 -tsObj.getFirstItem().getYDim() / 2 * samplingRate,
+                tsObjFirstItem = tsObj.getFirstItem()
+                origin.setShifts(-tsObjFirstItem.getXDim() / 2 * samplingRate,
+                                 -tsObjFirstItem.getYDim() / 2 * samplingRate,
                                  0)
 
                 if self.MDOC_DATA_SOURCE:

--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -207,7 +207,6 @@ class ProtImportTsBase(ProtImport, ProtTomoBase):
                        allowsNull=True,
                        help=Message.TEXT_MAGNI_RATE)
         group.addParam('samplingRate', params.FloatParam, # default=1.0,
-                       important=True,
                        label=Message.LABEL_SAMP_RATE,
                        allowsNull=True,
                        help=Message.TEXT_SAMP_RATE)

--- a/tomo/tests/test_import.py
+++ b/tomo/tests/test_import.py
@@ -384,7 +384,8 @@ class TestTomoImportTsFromMdoc(BaseTest):
     PIXEL_SIZE = 'pixelSize'
     SIZE = 'size'
     FILENAME_LIST = 'filenames'
-    ACCUM_DOSE_LIST = 'doses'
+    INCOMING_DOSE_LIST = 'incDoses'
+    ACCUM_DOSE_LIST = 'accumDoses'
     ANGLE_LIST = 'angles'
     ACQ_ORDER_LIST = 'acqOrder'
 
@@ -423,6 +424,7 @@ class TestTomoImportTsFromMdoc(BaseTest):
             cls.PIXEL_SIZE: kwargs.get(cls.PIXEL_SIZE, None),
             cls.SIZE: kwargs.get(cls.SIZE, None),
             cls.FILENAME_LIST: kwargs.get(cls.FILENAME_LIST, None),
+            cls.INCOMING_DOSE_LIST: kwargs.get(cls.INCOMING_DOSE_LIST, None),
             cls.ACCUM_DOSE_LIST: kwargs.get(cls.ACCUM_DOSE_LIST, None),
             cls.ANGLE_LIST: kwargs.get(cls.ANGLE_LIST, None),
             cls.ACQ_ORDER_LIST: kwargs.get(cls.ACQ_ORDER_LIST, None)
@@ -434,18 +436,21 @@ class TestTomoImportTsFromMdoc(BaseTest):
             testData = testDataDict[key]
             ind = numpy.argsort(testData[self.ANGLE_LIST])
 
-            newDoses = []
+            incDoses = []
+            accumDoses = []
             newAcqOrders = []
             newAngles = []
             newFiles = []
             for index in ind:
                 newAcqOrders.append(testData[self.ACQ_ORDER_LIST][index])
-                newDoses.append(testData[self.ACCUM_DOSE_LIST][index])
+                incDoses.append(testData[self.INCOMING_DOSE_LIST][index])
+                accumDoses.append(testData[self.ACCUM_DOSE_LIST][index])
                 newAngles.append(testData[self.ANGLE_LIST][index])
                 newFiles.append(testData[self.FILENAME_LIST][index])
 
             testData[self.ANGLE_LIST] = newAngles
-            testData[self.ACCUM_DOSE_LIST] = newDoses
+            testData[self.INCOMING_DOSE_LIST] = incDoses
+            testData[self.ACCUM_DOSE_LIST] = accumDoses
             testData[self.ACQ_ORDER_LIST] = newAcqOrders
 
     def _genTestData(self, isTsMovie):
@@ -460,7 +465,8 @@ class TestTomoImportTsFromMdoc(BaseTest):
                 pixelSize=self.sRate,
                 size=5,
                 filenames=self._getListOfFileNames(tomoNum=31, isTsMovie=isTsMovie),
-                doses=[1.1044, 2.2032, 3.3154, 4.4292, 5.5239],
+                incDoses=[1.1044, 1.0988, 1.1122, 1.1138, 1.0948],
+                accumDoses=[1.1044, 2.2032, 3.3154, 4.4292, 5.5239],
                 angles=[0.0036, 2.9683, -3.0250, -6.0251, 5.9684],
                 acqOrder=[1, 2, 3, 4, 5]
             ),
@@ -473,7 +479,8 @@ class TestTomoImportTsFromMdoc(BaseTest):
                 pixelSize=self.sRate,
                 size=5,
                 filenames=self._getListOfFileNames(tomoNum=10, isTsMovie=isTsMovie),
-                doses=[1.1722, 2.3432, 3.5145, 4.6831, 5.8514],
+                incDoses=[1.1722, 1.171, 1.1713, 1.1686, 1.1683],
+                accumDoses=[1.1722, 2.3432, 3.5145, 4.6831, 5.8514],
                 angles=[0.0026, 2.9708, -3.0255, -6.0241, 5.9684],
                 acqOrder=[1, 2, 3, 4, 5]
             )
@@ -514,6 +521,7 @@ class TestTomoImportTsFromMdoc(BaseTest):
             self.assertAlmostEqual(acq.getDosePerFrame(), testDataDict[self.DOSE_PER_FRAME], delta=0.0001)
             # Check angles and accumulated dose per angular acquisition (tilt series image)
             filesList = testDataDict[self.FILENAME_LIST]
+            incDoseList = testDataDict[self.INCOMING_DOSE_LIST]
             accumDoseList = testDataDict[self.ACCUM_DOSE_LIST]
             angleList = testDataDict[self.ANGLE_LIST]
             acqOrderList = testDataDict[self.ACQ_ORDER_LIST]
@@ -524,7 +532,8 @@ class TestTomoImportTsFromMdoc(BaseTest):
                 self.assertEqual(tiM.getFileName(), prot._getExtraPath(filesList[i]))
                 self.assertTrue(os.path.islink(tiM.getFileName()),
                                 "Tilt series file %s is not a link." % tiM.getFileName())
-                self.assertAlmostEqual(tiM.getAcquisition().getDosePerFrame(), accumDoseList[i], delta=0.0001)
+                self.assertAlmostEqual(tiM.getAcquisition().getDosePerFrame(), incDoseList[i], delta=0.0001)
+                self.assertAlmostEqual(tiM.getAcquisition().getAccumDose(), accumDoseList[i], delta=0.0001)
                 self.assertAlmostEqual(tiM.getTiltAngle(), angleList[i], delta=0.0001)
                 # objId must start with 1 --> i +1
                 self.assertEqual(i + 1, tiM.getObjId(), "Tilt image Movie objId is incorrect")

--- a/tomo/viewers/views_tkinter_tree.py
+++ b/tomo/viewers/views_tkinter_tree.py
@@ -53,10 +53,10 @@ class TiltSeriesTreeProvider(TreeProvider):
     COL_TI_ANGLE = 'Tilt Angle'
     COL_TI_ACQ_ORDER = 'Order'
     COL_TI_DEFOCUS_U = 'DefocusU (A)'
-    COL_TI_DOSE = "Dose"
+    COL_TI_DOSE = "AccumDose"
     ORDER_DICT = {COL_TI_ANGLE: '_tiltAngle',
                   COL_TI_DEFOCUS_U: '_ctfModel._defocusU',
-                  COL_TI_DOSE: '_acquisition._dosePerFrame'}
+                  COL_TI_DOSE: '_acquisition._accumDose'}
 
     def __init__(self, protocol, tiltSeries):
         self.protocol = protocol
@@ -98,7 +98,7 @@ class TiltSeriesTreeProvider(TreeProvider):
             (self.COL_TS, 100),
             (self.COL_TI_ACQ_ORDER, 100),
             (self.COL_TI_ANGLE, 100),
-            (self.COL_TI_DOSE, 50),
+            (self.COL_TI_DOSE, 100),
             (self.COL_TI, 400),
         ]
 
@@ -128,7 +128,7 @@ class TiltSeriesTreeProvider(TreeProvider):
             key = '%s.%s' % (tsId, objId)
             text = objId
 
-            dose = obj.getAcquisition().getDosePerFrame()
+            dose = obj.getAcquisition().getAccumDose()
             adqOrder = obj.getAcquisitionOrder()
 
             values = [str("%d" % adqOrder) if adqOrder is not None else "",

--- a/tomo/viewers/views_tkinter_tree.py
+++ b/tomo/viewers/views_tkinter_tree.py
@@ -48,12 +48,12 @@ class TiltSeriesTreeProvider(TreeProvider):
     """ Model class that will retrieve the information from TiltSeries and
     prepare the columns/rows models required by the TreeDialog GUI.
     """
-    COL_TS = 'Tilt Series'
+    COL_TS = 'Tilt series'
     COL_TI = 'Path'
-    COL_TI_ANGLE = 'Tilt Angle'
+    COL_TI_ANGLE = 'Tilt angle'
     COL_TI_ACQ_ORDER = 'Order'
-    COL_TI_DEFOCUS_U = 'DefocusU (A)'
-    COL_TI_DOSE = "AccumDose"
+    COL_TI_DEFOCUS_U = 'Defocus U (A)'
+    COL_TI_DOSE = "Accum. dose"
     ORDER_DICT = {COL_TI_ANGLE: '_tiltAngle',
                   COL_TI_DEFOCUS_U: '_ctfModel._defocusU',
                   COL_TI_DOSE: '_acquisition._accumDose'}


### PR DESCRIPTION
- Expand TomoAcquisition with the accumulated dose. As a consequence, update importTS, import tests and TS viewer

- Method getVolumeOrigin raises an exception if not volume is associated to the current 3D coordinate, something which commonly happens when generating coordinates

- Voltage, magnification and sampling rate are not required in the case of mdoc, but if they're filled, they'll have higher priority than the values read
