### PR TITLE
fix parsing of tiltseries in data obtained using serialEM

### DIFF
--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -1040,7 +1040,7 @@ class MDoc:
                     if self.getTiltAxisAngle():
                         continue  # It's in the mdoc, but the user has specified it manually
                     else:
-                        strLine = line.strip().replace(' ', '').lower()
+                        strLine = line.strip().replace(' ', '').replace(',','').lower()
                         pattern = 'tiltaxisangle='
                         if pattern in strLine:
                             # Example of the most common syntax (after having checked multiple mdocs from EMPIAR)


### PR DESCRIPTION
Sorry, the parsing of tiltseries value from serialEM need another fix.

    