### PR TITLE
do not average using missing wedge info in test

### DIFF
--- a/tomo/tests/test_transformations.py
+++ b/tomo/tests/test_transformations.py
@@ -174,7 +174,8 @@ def addAveragers(test, inputProt, outputName):
     # Add eman average method
     with weakImport("emantomo"):
         from emantomo.protocols import EmanProtSubTomoAverage
-        emanAve = test.newProtocol(EmanProtSubTomoAverage)
+        emanAve = test.newProtocol(EmanProtSubTomoAverage,
+                                   msWedge=0)
         emanAve.inputSetOfSubTomogram.set(inputProt)
         emanAve.inputSetOfSubTomogram.setExtended(outputName)
         test.launchProtocol(emanAve)


### PR DESCRIPTION
branch name is wrong. This just improves the tests results