### PR TITLE
Jj update ctftomoseries iterator

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -405,7 +405,15 @@ $if (-e ./savework) ./savework'.format(pathi, pathi, pathi,
         subsetStart = kwargs.get('subsetStart', (0, 0))
         actionIfGPUFails = kwargs.get('actionIfGPUFails', (1, 2))
 
-        dims = (self.getDim()[0], self.getDim()[1])
+        # The dimensions considered will be read, by default, from the corresponding tilt series. However, they
+        # can be specified via th kwarg dims, as can be the case of a resized tomogram, in which the X and Y dimensions
+        # considered in the tilt.com should be the ones corresponding to the tomogram
+        intorducedDims = kwargs.get('dims', None)  #
+        if intorducedDims:
+            dims = intorducedDims
+        else:
+            dims = (self.getDim()[0], self.getDim()[1])
+        # Swap dimensions case
         if kwargs.get('swapDims', False):
             dims = (dims[1], dims[0])
 

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -1332,6 +1332,7 @@ class SubTomogram(data.Volume):
 
     def setCoordinate3D(self, coordinate):
         self._coordinate = coordinate
+        self.setVolId(coordinate.getVolId())
 
     def getCoordinate3D(self):
         """Since the object Coordinate3D needs a volume, use the information stored in the


### PR DESCRIPTION
- Add setVolId call when setting the coordinate3D so it can be iterated
- Writing tilt.com files method admits now X and Y size given by a keyword. If not provided, these dimensions will be read from the TS