### PR TITLE
Jj fix generate tlt file method

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -268,7 +268,7 @@ class TiltSeriesBase(data.SetOfImages):
             angleList.reverse()
 
         with open(tltFilePath, 'w') as f:
-            f.writelines("%s\n" % angle for angle in angleList)
+            f.writelines("%.3f\n" % angle for angle in angleList)
 
     def hasOrigin(self):
         """ Method indicating if the TiltSeries object has a defined origin. """


### PR DESCRIPTION
Representing the angles with a big number of decimals can make trouble. For example, if the emantomo TS alignment, the angles are refined and stored with a lot of decimals, that are then written in a tlt file before reconstructing with any other algorithm, like tomo3d. In that case, tomo3d interprets the number of angles as more than one angle each, taking the first n ones to reconstruct and obtaining a bad reconstruction.

On the other hand, I think that 3 (as proposed) or 4 decimal positions are more than enough in terms of angle precision.