### PR TITLE
Fix error when tomogram set does not completely contain the set of coordinates

### DIFF
--- a/tomo/protocols/protocol_ts_convert_coords3d.py
+++ b/tomo/protocols/protocol_ts_convert_coords3d.py
@@ -132,7 +132,7 @@ class ProtTsConvertCoordinates3d(EMProtocol, ProtTomoBase):
         tomoDict = {}
 
         for tomo in self.inputSetOfTomograms.get():
-            tomoDict[tomo.getObjId()] = tomo
+            tomoDict[tomo.getTsId()] = tomo
 
         return tomoDict
 

--- a/tomo/protocols/protocol_ts_convert_coords3d.py
+++ b/tomo/protocols/protocol_ts_convert_coords3d.py
@@ -85,15 +85,19 @@ class ProtTsConvertCoordinates3d(EMProtocol, ProtTomoBase):
             tsId = coor3d.getTsId()
             tomo = self.getTomoFromTsId(tsId)
 
-            newCoord3D = tomoObj.Coordinate3D()
-            newCoord3D.setVolume(tomo)
-            newCoord3D.setX(coor3d.getX()/sr, CENTER_GRAVITY)
-            newCoord3D.setY(coor3d.getY()/sr, CENTER_GRAVITY)
-            newCoord3D.setZ(-coor3d.getZ()/sr, CENTER_GRAVITY)
+            if isinstance(tomo, bool) and not tomo:
+                pass
 
-            newCoord3D.setVolId(tomo.getObjId())
-            self.outputSetOfCoordinates3D.append(newCoord3D)
-            self.outputSetOfCoordinates3D.update(newCoord3D)
+            else:
+                newCoord3D = tomoObj.Coordinate3D()
+                newCoord3D.setVolume(tomo)
+                newCoord3D.setX(coor3d.getX()/sr, CENTER_GRAVITY)
+                newCoord3D.setY(coor3d.getY()/sr, CENTER_GRAVITY)
+                newCoord3D.setZ(-coor3d.getZ()/sr, CENTER_GRAVITY)
+
+                newCoord3D.setVolId(tomo.getObjId())
+                self.outputSetOfCoordinates3D.append(newCoord3D)
+                self.outputSetOfCoordinates3D.update(newCoord3D)
 
         self.outputSetOfCoordinates3D.write()
 
@@ -129,6 +133,7 @@ class ProtTsConvertCoordinates3d(EMProtocol, ProtTomoBase):
         for tomo in self.inputSetOfTomograms.get():
             if tomo.getTsId() == tsId:
                 return tomo
+        return False
 
     # --------------------------- INFO functions ----------------------------
     def _summary(self):

--- a/tomo/protocols/protocol_ts_convert_coords3d.py
+++ b/tomo/protocols/protocol_ts_convert_coords3d.py
@@ -80,15 +80,14 @@ class ProtTsConvertCoordinates3d(EMProtocol, ProtTomoBase):
         sr = self.inputSetOfTomograms.get().getSamplingRate()
 
         self.getOutputSetOfCoordinates3Ds()
+        tomoDict = self.getTomoDict()
 
         for coor3d in sotsc3d:
             tsId = coor3d.getTsId()
-            tomo = self.getTomoFromTsId(tsId)
 
-            if isinstance(tomo, bool) and not tomo:
-                pass
+            if tsId in tomoDict.keys():
+                tomo = tomoDict[tsId]
 
-            else:
                 newCoord3D = tomoObj.Coordinate3D()
                 newCoord3D.setVolume(tomo)
                 newCoord3D.setX(coor3d.getX()/sr, CENTER_GRAVITY)
@@ -129,11 +128,13 @@ class ProtTsConvertCoordinates3d(EMProtocol, ProtTomoBase):
 
         return self.outputSetOfCoordinates3D
 
-    def getTomoFromTsId(self, tsId):
+    def getTomoDict(self):
+        tomoDict = {}
+
         for tomo in self.inputSetOfTomograms.get():
-            if tomo.getTsId() == tsId:
-                return tomo
-        return False
+            tomoDict[tomo.getObjId()] = tomo
+
+        return tomoDict
 
     # --------------------------- INFO functions ----------------------------
     def _summary(self):


### PR DESCRIPTION
This PR includes:
- Fixes in convert tilt series coordinates to 3D coordinates when tomogram set does not completely contain the set of coordinates