### PR TITLE
ComposeTiltSeries: ObjID starts with 1 not 0

### DIFF
--- a/tomo/protocols/protocol_compose_TS.py
+++ b/tomo/protocols/protocol_compose_TS.py
@@ -373,7 +373,7 @@ class ProtComposeTS(ProtImport, ProtTomoBase):
                         ti = tomoObj.TiltImage()
                         ti.setLocation(mic.getFileName())
                         ti.setTsId(ts_obj.getObjId())
-                        ti.setObjId(counter_ti)
+                        ti.setObjId(counter_ti + 1)
                         ti.setIndex(counter_ti + 1)
                         ti.setAcquisitionOrder(int(to))
                         ti.setTiltAngle(ta)


### PR DESCRIPTION
With the change, areTomo creates the tomogram. 
Tested with real tilts in galileo-shadow (agarcia user)