### PR TITLE
accepting dose accumulation in the tlt file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,6 @@
 v3.1.0:
   - First plugin release.See README.rst for more details
   - Tomography 2022 course: 5 templates added. Need You'll need to download its dataset -> scipion3 testdata --download tomo-tutorial
+v3.1.4:
+- Added an option to import the dose accumulation using a tlt file as second column
 

--- a/tomo/convert/__init__.py
+++ b/tomo/convert/__init__.py
@@ -101,14 +101,15 @@ def getAnglesFromMdoc(mdocFn):
     return [float(d['TiltAngle']) for d in parseMdoc(mdocFn)]
 
 
-def getAnglesFromTlt(tltFn):
+def getAnglesAndDosesFromTlt(tltFn):
     """ Parse the tilt-angles from tlt file. """
     angles = []
-
+    doses = []
     with open(tltFn) as f:
         for line in f:
-            line = line.strip()
+            line = line.strip().split(" ")
             if line:
-                angles.append(float(line))
-
-    return angles
+                angles.append(float(line[0]))
+                if len(line) == 2:
+                    doses.append(float(line[1]))
+    return angles, doses

--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -945,7 +945,9 @@ class ProtImportTs(ProtImportTsBase):
                             "or from the image header, or from an"
                             "mdoc or tlt file (should have the SAME filename "
                             "but with the .mdoc or .tlt or .rawtlt "
-                            "extension at the end).")
+                            "extension at the end). If a tlt or rawtlt file is used, "
+                            "it is optional to pass the accumulated dose as second "
+                            "column beside each angle separated by space")
 
         line = group.addLine('Tilt angles range',
                              condition='anglesFrom==0',  # ANGLES_FROM_RANGE

--- a/tomo/protocols/protocol_ts_import.py
+++ b/tomo/protocols/protocol_ts_import.py
@@ -376,12 +376,7 @@ class ProtImportTsBase(ProtImport, ProtTomoBase):
                             doses = []
                             anglesFrom = self.getEnumText('anglesFrom')
                             if anglesFrom == self.ANGLES_FROM_TLT:
-                                tltFn = os.path.splitext(imageFile)[0] + '.tlt'
-                                rawtltFn = tltFn.replace(".tlt", ".rawtlt")
-                                if os.path.exists(tltFn):
-                                    _, doses = getAnglesAndDosesFromTlt(tltFn)
-                                elif os.path.exists(rawtltFn):
-                                    _, doses = getAnglesAndDosesFromTlt(rawtltFn)
+                                _, doses = self.getFromTlt(imageFile)
                             if doses:
                                 accumDose = doses[counter]
                             else:
@@ -761,14 +756,7 @@ class ProtImportTsBase(ProtImport, ProtTomoBase):
                     raise Exception("Missing angles file: %s" % mdocFn)
                 angles = getAnglesFromMdoc(mdocFn)
             elif anglesFrom == self.ANGLES_FROM_TLT:
-                tltFn = os.path.splitext(file)[0] + '.tlt'
-                rawtltFn = tltFn.replace(".tlt", ".rawtlt")
-                if os.path.exists(tltFn):
-                    angles, _ = getAnglesAndDosesFromTlt(tltFn)
-                elif os.path.exists(rawtltFn):
-                    angles, _ = getAnglesAndDosesFromTlt(rawtltFn)
-                else:
-                    raise Exception("Missing angles file: %s or %s" % (tltFn, rawtltFn))
+                angles, _ = self.getFromTlt(file)
             elif anglesFrom == self.ANGLES_FROM_RANGE:
                 angles = self._getTiltAngleRange()
             else:
@@ -836,6 +824,18 @@ class ProtImportTsBase(ProtImport, ProtTomoBase):
     def isBlacklisted(self, fileName):
         """ Overwrite in subclasses """
         return False
+
+    def getFromTlt(self, file):
+        """ Gets angles and doses from a tlt or rawtlt file """
+        tltFn = os.path.splitext(file)[0] + '.tlt'
+        rawtltFn = tltFn.replace(".tlt", ".rawtlt")
+        if os.path.exists(tltFn):
+            angles, doses = getAnglesAndDosesFromTlt(tltFn)
+        elif os.path.exists(rawtltFn):
+            angles, doses = getAnglesAndDosesFromTlt(rawtltFn)
+        else:
+            raise Exception("Missing angles file: %s or %s" % (tltFn, rawtltFn))
+        return angles, doses
 
     @classmethod
     def worksInStreaming(cls):


### PR DESCRIPTION
In this PR I added the option (does not impact previous usage) to import the accumulated dose of a tilt series as a second column in the tlt/rawtlt file.
This is not a new practice, it is already allowed in the same way in aretomo (see manual section Dose Weighting).
