### PR TITLE
hide transform matrix column for TS movies; change TS flags

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+v3.1.5:
+    - hide transform matrix column for TS movies
+    - fix CTF viewer help (close #253)
+    - change TS flags
+v3.1.4:
+- Added an option to import the dose accumulation using a tlt file as second column
 v3.1.3:
  users:
   - Tutorials templates renamed
@@ -16,6 +22,3 @@ V3.1.1:
 v3.1.0:
   - First plugin release.See README.rst for more details
   - Tomography 2022 course: 5 templates added. Need You'll need to download its dataset -> scipion3 testdata --download tomo-tutorial
-v3.1.4:
-- Added an option to import the dose accumulation using a tlt file as second column
-

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,8 @@
-v3.1.5:
+v3.1.4:
     - hide transform matrix column for TS movies
     - fix CTF viewer help (close #253)
     - change TS flags
-v3.1.4:
-- Added an option to import the dose accumulation using a tlt file as second column
+    - Added an option to import the dose accumulation using a tlt file as second column
 v3.1.3:
  users:
   - Tutorials templates renamed

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,13 @@
-================
+===========
 Tomo plugin
-================
+===========
 
 Base Scipion plugin for electron cryo-tomography and subtomogram averaging.
 
-Current development
--------------------
-
 This plugin is currently in **BETA** mode.
 
-
-Installation
-------------
-
-You will need to use `3.0.0 <https://scipion-em.github.io/docs/release-3.0.0/docs/scipion-modes/how-to-install.html>`_ version of Scipion to run these protocols.
-
-
 Protocols
------------
+---------
 
 * **import tilt-series**: Protocol to import tilt series.
 * **import tilt-series movies**: Protocol to import tilt series movies.
@@ -68,7 +58,7 @@ Clone or download the plugin repository
 
 .. code-block::
 
-    git clone https://github.com/scipion-em/scipion-em-tomo.git
+    git clone -b devel https://github.com/scipion-em/scipion-em-tomo.git
 
 Install the plugin in developer mode.
 

--- a/tomo/__init__.py
+++ b/tomo/__init__.py
@@ -26,7 +26,7 @@
 
 import pwem
 
-__version__ = '3.1.5'
+__version__ = '3.1.4'
 _logo = "icon.png"
 _references = []
 

--- a/tomo/__init__.py
+++ b/tomo/__init__.py
@@ -26,7 +26,7 @@
 
 import pwem
 
-__version__ = '3.1.3'
+__version__ = '3.1.5'
 _logo = "icon.png"
 _references = []
 
@@ -39,4 +39,3 @@ class Plugin(pwem.Plugin):
     @classmethod
     def getEnviron(cls):
         return None
-

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -375,7 +375,7 @@ def tiltSeriesToString(tiltSeries):
     if tiltSeries.ctfCorrected():
         s.append('ctfCorr')
 
-    return (", " + ",".join(s)) if len(s) else ""
+    return (", " + ", ".join(s)) if len(s) else ""
 
 
 class TiltSeries(TiltSeriesBase):

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -365,15 +365,15 @@ def tiltSeriesToString(tiltSeries):
     s = []
     # Matrix info
     if tiltSeries.hasAlignment():
-        s.append(u'\u21c4 hasAln')
+        s.append('✔ ali')
 
     # Interpolated
     if tiltSeries.interpolated():
-        s.append(u'\u21f2 interp')
+        s.append('❗ interp')
 
     # CTF status
     if tiltSeries.ctfCorrected():
-        s.append('ctfCorr')
+        s.append('✔ ctf')
 
     return (", " + ", ".join(s)) if len(s) else ""
 

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -362,16 +362,20 @@ class TiltSeriesBase(data.SetOfImages):
 
 
 def tiltSeriesToString(tiltSeries):
+    s = []
     # Matrix info
-    s = '∅' if not tiltSeries.hasAlignment() else '＊'
+    if tiltSeries.hasAlignment():
+        s.append(u'\u21c4 hasAln')
 
     # Interpolated
-    s += ', interp' if tiltSeries.interpolated() else ''
+    if tiltSeries.interpolated():
+        s.append(u'\u21f2 interp')
 
     # CTF status
-    s += ', ctf' if tiltSeries.ctfCorrected() else ''
+    if tiltSeries.ctfCorrected():
+        s.append('ctfCorr')
 
-    return s
+    return (", " + ",".join(s)) if len(s) else ""
 
 
 class TiltSeries(TiltSeriesBase):
@@ -746,7 +750,7 @@ class SetOfTiltSeries(SetOfTiltSeriesBase):
         s = '%s x %s x %s' % (self._anglesCount,
                               self._firstDim[0],
                               self._firstDim[1])
-        s += ', ' + tiltSeriesToString(self)
+        s += tiltSeriesToString(self)
 
         return s
 

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -365,15 +365,15 @@ def tiltSeriesToString(tiltSeries):
     s = []
     # Matrix info
     if tiltSeries.hasAlignment():
-        s.append('✔ ali')
+        s.append('+ali')
 
     # Interpolated
     if tiltSeries.interpolated():
-        s.append('❗ interp')
+        s.append('! interp')
 
     # CTF status
     if tiltSeries.ctfCorrected():
-        s.append('✔ ctf')
+        s.append('+ctf')
 
     return (", " + ", ".join(s)) if len(s) else ""
 


### PR DESCRIPTION
This is my lame attempt (I'm not a UI designer) to improve TS flags. Unfortunately, obj summary does not allow images/icons, only text.. 

- if TS has no alignment, it should not have any labels/flags. Otherwise you would need labels for no ctf, no xxx, no yyy which makes no sense and causes more confusion
- since we can't have any text on hower, a text label nearby is good to have: ⇄ hasAln, ⇲ interp

Also closes #253 
