### PR TITLE
fix step deps if no process Ti used

### DIFF
--- a/tomo/protocols/protocol_ts_base.py
+++ b/tomo/protocols/protocol_ts_base.py
@@ -72,6 +72,8 @@ class ProtTsProcess(EMProtocol, ProtTomoBase):
                         *self._getArgs(), prerequisites=[self._ciStepId])
                     tsSteps.append(tiStep)
 
+            if not tsSteps:  # no Ti steps used
+                tsSteps.append(self._ciStepId)
             tsStepId = self._insertFunctionStep('processTiltSeriesStep', tsId,
                                                 prerequisites=tsSteps)
             self._coStep.addPrerequisites(tsStepId)


### PR DESCRIPTION
Otherwise the processTiltSeriesStep runs in parallel with convertInputStep, which is wrong