### PR TITLE
Napari 0.4.17 is the default version. boxmanager and tomotwin are now…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 v3.5.0:
   - Prevent viewers from locking the screen focus.
+  - Napari 0.4.17 is the default version. boxmanager and tomotwin are now independent
 v3.4.2:
   - TS movies not hiding any acquisition parameter to prevent accidental override.
 v3.4.1:

--- a/tomo/__init__.py
+++ b/tomo/__init__.py
@@ -27,7 +27,7 @@
 import os
 import pwem
 from .constants import (NAPARI_ENV_ACTIVATION, NAPARI_ACTIVATION_CMD,
-                        getNaparyEnvName, V0_3_11, NAPARI_DEF_VER)
+                        getNaparyEnvName, NAPARI_DEF_VER)
 
 __version__ = '3.5.0'
 _logo = "icon.png"
@@ -60,9 +60,9 @@ class Plugin(pwem.Plugin):
         NAPARI_INSTALLED = f"napari_{version}_installed"
         installCmd = [cls.getCondaActivationCmd(),
                       f'conda create -y -n {ENV_NAME} -c conda-forge',
-                      'python=3.10 napari=0.4.17 pyqt pip &&',
+                      f'python=3.10 napari={version} pyqt pip &&',
                       f'conda activate {ENV_NAME} &&',
-                      f'pip install napari-tomotwin napari-boxmanager=={version}']
+                      f'pip install napari-tomotwin napari-boxmanager']
 
         # Flag installation finished
         installCmd.append(f'&& touch {NAPARI_INSTALLED}')
@@ -81,5 +81,4 @@ class Plugin(pwem.Plugin):
 
     @classmethod
     def defineBinaries(cls, env):
-        cls.addNapariPackage(env, V0_3_11)
         cls.addNapariPackage(env, NAPARI_DEF_VER, default=True)

--- a/tomo/__init__.py
+++ b/tomo/__init__.py
@@ -62,7 +62,7 @@ class Plugin(pwem.Plugin):
                       f'conda create -y -n {ENV_NAME} -c conda-forge',
                       f'python=3.10 napari={version} pyqt pip &&',
                       f'conda activate {ENV_NAME} &&',
-                      f'pip install napari-tomotwin napari-boxmanager']
+                      'pip install napari-tomotwin napari-boxmanager']
 
         # Flag installation finished
         installCmd.append(f'&& touch {NAPARI_INSTALLED}')

--- a/tomo/constants.py
+++ b/tomo/constants.py
@@ -73,9 +73,8 @@ def getNaparyEnvName(version):
     return f"napari-{version}"
 
 
-V0_3_11 = '0.3.11'
-V0_4_4 = '0.4.4'
+V0_4_17 = '0.4.17'
 
-NAPARI_DEF_VER = V0_4_4
+NAPARI_DEF_VER = V0_4_17
 NAPARI_ACTIVATION_CMD = 'conda activate %s' % getNaparyEnvName(NAPARI_DEF_VER)
 NAPARI_ENV_ACTIVATION = 'NAPARI_ENV_ACTIVATION'


### PR DESCRIPTION
… independent