### PR TITLE
pass kwargs to iterItems of ctf tomo

### DIFF
--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -2804,8 +2804,9 @@ class SetOfCTFTomoSeries(data.EMSet):
         self._setItemMapperPath(classItem)
         return classItem
 
-    def iterItems(self, orderBy='id', direction='ASC'):
-        for item in super().iterItems(orderBy=orderBy, direction=direction):
+    def iterItems(self, orderBy='id', direction='ASC', **kwargs):
+        for item in super().iterItems(orderBy=orderBy,
+                                      direction=direction, **kwargs):
 
             ts = self._getTiltSeriesFromTsId(item.getTsId())
             if ts is None:


### PR DESCRIPTION
This will allow to replace:

```
for ctfTomoSeries in self.inputSetOfCtfTomoSeries.get():
    if tsId == ctfTomoSeries.getTsId():
        return ctfTomoSeries
```

with:
```
for item in self.inputSetOfCtfTomoSeries.get().iterItems(where=f"_tsId=='{tsId}'"):
    return item
```

I don't see any other method in the tomo objects to get ctftomo by tsId