### PR TITLE
  - TCL expansion and small fixes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ v3.6.0:
  Developers:
   - Test dataset relion40_sta_tutorial_data expanded.
   - TCL: methods dor checking sets of TS and TsM improved.
+  - Class Tomogram method getDim removed as it did not manage heterogeneous sets correctly when iterating (read the
+    header once, stored it and reused). The Volume method is used now instead, as it reads the size from the file
+    header for each file.
 v3.5.0:
  Users:
   - Improve the TiltSeries viewer. Allowing to exclude TiltImages

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+v3.6.1:
+ Developers:
+  - Fix: class Tomogram method getDim removed as it did not manage heterogeneous sets correctly when iterating (read the
+    header once, stored it and reused). The Volume method is used now instead, as it reads the size from the file
+    header for each file.
 v3.6.0:
  Users:
   - Tilt series subsets and CTFTomoseries clone the enable flag

--- a/tomo/__init__.py
+++ b/tomo/__init__.py
@@ -29,7 +29,7 @@ import pwem
 from .constants import (NAPARI_ENV_ACTIVATION, NAPARI_ACTIVATION_CMD,
                         getNaparyEnvName, NAPARI_DEF_VER)
 
-__version__ = '3.6.0'
+__version__ = '3.6.1'
 _logo = "icon.png"
 _references = []
 

--- a/tomo/objects.py
+++ b/tomo/objects.py
@@ -1110,27 +1110,6 @@ class Tomogram(data.Volume):
                 and self._acquisition.getAngleMin() is not None
                 and self._acquisition.getAngleMax() is not None)
 
-    def getDim(self):
-        """Return image dimensions as tuple: (Xdim, Ydim, Zdim)"""
-        if self._dim is None:
-            from pwem.emlib.image import ImageHandler
-
-            fn = self.getFileName()
-            if fn is not None and os.path.exists(fn.replace(':mrc', '')):
-                x, y, z, n = ImageHandler().getDimensions(self)
-
-                # Some volumes in mrc format can have the z dimension
-                # as n dimension, so we need to consider this case.
-                if z > 1:
-                    self._dim = (x, y, z)
-                    return x, y, z
-                else:
-                    self._dim = (x, y, n)
-                    return x, y, n
-        else:
-            return self._dim
-        return None
-
     def copyInfo(self, other):
         """ Copy basic information """
         super().copyInfo(other)

--- a/tomo/tests/__init__.py
+++ b/tomo/tests/__init__.py
@@ -1,8 +1,8 @@
 # **************************************************************************
 # *
-# * Authors:     J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [1]
+# * Authors:     Scipion Team (scipion@cnb.csic.es) [1]
 # *
-# * [1] SciLifeLab, Stockholm University
+# * [1] Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -26,6 +26,7 @@
 from enum import Enum
 
 from pyworkflow.tests import DataSet
+from tomo.objects import TomoAcquisition
 
 DataSet(name='tomo-em', folder='tomo-em',
         files={
@@ -61,11 +62,12 @@ DataSet(name='reliontomo', folder='reliontomo',
 
 DataSet(name='tomoMask', folder='tomoMask',
         files={
-               'vTomo1': 'vTomo1_flt.mrc',
-               'vTomo2': 'vTomo2_flt.mrc',
-               'meshCoordinates': 'meshCoordinates.csv',
+            'vTomo1': 'vTomo1_flt.mrc',
+            'vTomo2': 'vTomo2_flt.mrc',
+            'meshCoordinates': 'meshCoordinates.csv',
         })
 
+########################################################################################################################
 EMD_10439 = 'emd_10439'
 
 
@@ -88,30 +90,94 @@ class DataSetEmd10439(Enum):
 
 DataSet(name=EMD_10439, folder=EMD_10439, files={el.name: el.value for el in DataSetEmd10439})
 
+########################################################################################################################
+RE4_STA_TUTO = 'relion40_sta_tutorial_data'
+
+TS_54 = 'TS_54'
+TS_03 = 'TS_03'
+nAnglesDict = {TS_03: 40,
+               TS_54: 41}
+expectedDimsTsDict = {TS_03: [3710, 3838, 40],
+                      TS_54: [3710, 3838, 41]}
+expectedDimsTsInterpDict = {TS_03: [3838, 3710, 40],
+                            TS_54: [3838, 3710, 41]}
+
+# Acquisition
+voltage = 300
+sphericalAb = 2.7
+amplitudeContrast = 0.07
+magnification = 105000
+tiltAxisAngle = 85.3
+tiltStep = 3
+initialDose = 0
+dosePerTiltImgWithTltFile = 3
+
+# Acquisition common parameters
+dosePerTiltImg = dosePerTiltImgWithTltFile
+testAcq = TomoAcquisition(voltage=voltage,
+                          sphericalAberration=sphericalAb,
+                          amplitudeContrast=amplitudeContrast,
+                          magnification=magnification,
+                          doseInitial=initialDose,
+                          tiltAxisAngle=tiltAxisAngle,
+                          dosePerFrame=dosePerTiltImg,
+                          angleMax=60,
+                          step=tiltStep)
+# Acquisition of TS_03
+testAcq03 = testAcq.clone()
+testAcq03.setAngleMin(-57)
+testAcq03.setAccumDose(dosePerTiltImg * nAnglesDict[TS_03])
+# Acquisition of TS_54
+testAcq54 = testAcq.clone()
+testAcq54.setAngleMin(-60)
+testAcq54.setAccumDose(dosePerTiltImg * nAnglesDict[TS_54])
+# Tilt series acq dict
+tsAcqDict = {TS_03: testAcq03,
+             TS_54: testAcq54}
+# Acquisition of TS_03 interpolated
+testAcq03Interp = testAcq03.clone()
+testAcq03Interp.setTiltAxisAngle(0)
+# Acquisition of TS_54 interpolated
+testAcq54Interp = testAcq54.clone()
+testAcq54Interp.setTiltAxisAngle(0)
+# Tilt series interpolated acq dict
+tsAcqInterpDict = {TS_03: testAcq03Interp,
+                   TS_54: testAcq54Interp}
+
 
 class DataSetRe4STATuto(Enum):
-    voltage = 300
-    sphericalAb = 2.7
-    amplitudeContrast = 0.07
-    magnification = 105000
+    voltage = voltage
+    sphericalAb = sphericalAb
+    amplitudeContrast = amplitudeContrast
+    magnification = magnification
     unbinnedPixSize = 1.35
     boxSizeBin4 = 192
     boxSizeBin2 = 256
     croppedBoxSizeBin4 = 96
     croppedBoxSizeBin2 = 128
-    tiltAxisAngle = 85.3
-    initialDose = 0
-    dosePerTiltImg = 3.05
-    dosePerTiltImgWithTltFile = 3
+    tiltAxisAngle = tiltAxisAngle
+    initialDose = initialDose
+    dosePerTiltImg = 3.05  # Mean dose
+    dosePerTiltImgWithTltFile = dosePerTiltImgWithTltFile
     exclusionWordsTs03 = 'output 01 43 45 54'
     exclusionWordsTs03ts54 = 'output 01 43 45'
     correctCoordsFormula = 'item._y.set(item._y.get() + 18)'
     symmetry = 'C6'
+    # Acquisition
+    testAcq03 = testAcq03
+    testAcq54 = testAcq54
+    tsAcqDict = tsAcqDict
+    testAcq03Interp = testAcq03Interp
+    testAcq54Interp = testAcq54Interp
+    tsAcqInterpDict = tsAcqInterpDict
     # Tilt series
     tsPath = 'tomograms'
     tsPattern = '*/{TS}.mrc'
     transformPattern = 'TS*/*.xf'
     ctfPattern = '*/*.defocus'
+    nAnglesDict = nAnglesDict
+    dimsTsBin1Dict = expectedDimsTsDict
+    dimsTsInterpBin1Dict = expectedDimsTsInterpDict
     # Tomograms
     tomosPath = 'tomograms'
     tomosPattern = '*.mrc'
@@ -135,5 +201,4 @@ class DataSetRe4STATuto(Enum):
     aretomoCtfFilesPath = 'testAreTomoCtf'
 
 
-RE4_STA_TUTO = 'relion40_sta_tutorial_data'
 DataSet(name=RE4_STA_TUTO, folder=RE4_STA_TUTO, files={el.name: el.value for el in DataSetRe4STATuto})

--- a/tomo/tests/__init__.py
+++ b/tomo/tests/__init__.py
@@ -97,11 +97,6 @@ TS_54 = 'TS_54'
 TS_03 = 'TS_03'
 nAnglesDict = {TS_03: 40,
                TS_54: 41}
-expectedDimsTsDict = {TS_03: [3710, 3838, 40],
-                      TS_54: [3710, 3838, 41]}
-expectedDimsTsInterpDict = {TS_03: [3838, 3710, 40],
-                            TS_54: [3838, 3710, 41]}
-
 # Acquisition
 voltage = 300
 sphericalAb = 2.7
@@ -176,8 +171,8 @@ class DataSetRe4STATuto(Enum):
     transformPattern = 'TS*/*.xf'
     ctfPattern = '*/*.defocus'
     nAnglesDict = nAnglesDict
-    dimsTsBin1Dict = expectedDimsTsDict
-    dimsTsInterpBin1Dict = expectedDimsTsInterpDict
+    dimsTsBin1Dict = {TS_03: [3710, 3838, 40], TS_54: [3710, 3838, 41]}
+    dimsTsInterpBin1Dict = {TS_03: [3838, 3710, 40], TS_54: [3838, 3710, 41]}
     # Tomograms
     tomosPath = 'tomograms'
     tomosPattern = '*.mrc'

--- a/tomo/tests/test_base_centralized_layer.py
+++ b/tomo/tests/test_base_centralized_layer.py
@@ -31,7 +31,7 @@ from pwem.objects import Transform
 from pyworkflow.tests import BaseTest
 from tomo.constants import TR_SCIPION, SCIPION
 from tomo.objects import SetOfSubTomograms, SetOfCoordinates3D, Coordinate3D, Tomogram, CTFTomoSeries, SetOfTiltSeries, \
-    TomoAcquisition, SetOfTiltSeriesM, TiltSeries, TiltImage
+    TomoAcquisition, SetOfTiltSeriesM, TiltSeries, TiltImage, SetOfTomograms
 
 
 class TestBaseCentralizedLayer(BaseTest):
@@ -322,13 +322,19 @@ class TestBaseCentralizedLayer(BaseTest):
         # TODO: Check if the CTFs could be checked more exhaustively
 
     # TOMOGRAMS ########################################################################################################
-    def checkTomograms(self, inTomoSet, expectedSetSize=-1, expectedSRate=-1, expectedDimensions=None,
-                       hasOddEven=False, expectedOriginShifts=None, hasCtf=False, hasHalves=False):
+    def checkTomograms(self, inTomoSet: SetOfTomograms, expectedSetSize: int, expectedSRate: float,
+                       expectedDimensions: Union[List[int], dict] = None,
+                       hasOddEven: bool = False,
+                       expectedOriginShifts: List[float] = None,
+                       hasCtf: bool = False,
+                       hasHalves: bool = False):
         """
         :param inTomoSet: SetOfSubTomograms.
         :param expectedSetSize: expected set site to check.
         :param expectedSRate: expected sampling rate, in Å/pix, to check.
-        :param expectedDimensions: list containing the expected X,Y, and Z dimensions, in pixels, to check.
+        :param expectedDimensions: list containing the expected X,Y, and Z dimensions, in pixels, to check. A dict of
+        structure {key --> tsId: value: expectedDimensions} is also admitted in the case of heterogeneous sets, e.g.
+        TS with different number of tilt images.
         :param hasOddEven: False by default. Used to indicate if the set of tomograms is expected to have even/odd
         halves.
         :param expectedOriginShifts: list containing the expected shifts of the tomogram center in the X, Y, and Z
@@ -361,7 +367,10 @@ class TestBaseCentralizedLayer(BaseTest):
             # Check the dimensions
             if expectedDimensions:
                 x, y, z = tomo.getDimensions()
-                self.assertEqual([x, y, z], expectedDimensions, msg=checkSizeMsg)
+                if type(expectedDimensions) is dict:
+                    self.assertEqual([x, y, z], expectedDimensions[tomo.getTsId()], msg=checkSizeMsg)
+                else:
+                    self.assertEqual([x, y, z], expectedDimensions, msg=checkSizeMsg)
 
             # Check the origin
             if expectedOriginShifts:


### PR DESCRIPTION
 Developers:
  - Test dataset relion40_sta_tutorial_data expanded.
  - TCL: methods for checking sets of TS and TsM improved.
  - Class Tomogram method getDim removed as it did not manage heterogeneous sets correctly when iterating (read the
    header once, stored it and reused). The Volume method is used now instead, as it reads the size from the file
    header for each file.