### PR TITLE
Gs restacking fixes

### DIFF
--- a/tomo/protocols/protocol_ts_correct_motion.py
+++ b/tomo/protocols/protocol_ts_correct_motion.py
@@ -54,7 +54,7 @@ class ProtTsCorrectMotion(ProtTsProcess):
     the frames range used for alignment and final sum, the binning factor
     or the cropping options (region of interest)
     """
-    _possibleOutputs = {'outputTiltSeries': SetOfTiltSeries,
+    _possibleOutputs = {'TiltSeries': SetOfTiltSeries,
                         OUTPUT_TILT_SERIES_DW: SetOfTiltSeries,
                         OUTPUT_TILT_SERIES_EVEN: SetOfTiltSeries,
                         OUTPUT_TILT_SERIES_ODD: SetOfTiltSeries}

--- a/tomo/viewers/views_tkinter_tree.py
+++ b/tomo/viewers/views_tkinter_tree.py
@@ -492,7 +492,8 @@ class TiltSeriesDialog(ToolbarListDialog):
                         included = False if ti.getObjId() in excludedViews[tsId] else True
                         if not restack or (included and restack):
                             newTi = ti.clone()
-                            newTi.copyInfo(ti, copyId=True)
+                            newTi.copyInfo(ti, copyId=False)
+                            newTi.setObjId(None)
                             newTi.setAcquisition(ti.getAcquisition())
                             # For some reason .clone() does not clone the enabled nor the creation time
                             newTi.setEnabled(included)
@@ -518,6 +519,7 @@ class TiltSeriesDialog(ToolbarListDialog):
                     if len(excludedViews[ts.getTsId()]) == ts.getSize():
                         newTs.setEnabled(False)
                     newTs.setDim(ts.getDim())
+                    newTs.setAnglesCount(newTs.getSize())
                     newTs.write()
                     outputSetOfTiltSeries.update(newTs)
                     outputSetOfTiltSeries.write()


### PR DESCRIPTION
1) renumber TI objIds when restacking (Close #524) *
2) remove output prefix
3) fix angles count

\* I do not know how this may affect acq order or other recent ctf-related code