### PR TITLE
Refactor mesh from segmentation protocol

### DIFF
--- a/tomo/protocols/protocol_mesh_from_segmentation.py
+++ b/tomo/protocols/protocol_mesh_from_segmentation.py
@@ -1,6 +1,7 @@
 # **************************************************************************
 # *
 # * Authors:     J.L. Vilas (jlvilas@cnb.csic.es)
+# *              Oier Lauzirika Zarrabeita (oierlauzi@bizkaia.eu)
 # *
 # * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *
@@ -115,7 +116,7 @@ class ProtMeshFromSegmentation(EMProtocol, ProtTomoBase):
         if mask is not None:
             tomogram = self._getInputTomogram(tsId)
             outputMeshes = getattr(self, self._OUTPUT_NAME)
-            maskData = None # TODO
+            maskData = self._loadMask(mask)
     
             if self.segmentation:
                 self._processSegmentation(
@@ -187,16 +188,16 @@ class ProtMeshFromSegmentation(EMProtocol, ProtTomoBase):
                            mesh: SetOfMeshes,
                            tomogram: Tomogram,
                            mask: np.ndarray ):
-        probability = self.density.get / 100
+        probability = self.density.get() / 100.0
         coordinates = np.argwhere(mask)
         indices = np.arange(0, len(coordinates))
         nPoints = math.floor(probability*len(indices))
         selection = np.random.choice(indices, size=nPoints, replace=False)
         
-        point = MeshPoint()
-        point.setVolume(tomogram)
-        point.setGroupId(self.baseGroupId)
         for z, y, x in coordinates[selection,:]:
+            point = MeshPoint()
+            point.setVolume(tomogram)
+            point.setGroupId(self.baseGroupId)
             point.setPosition(x, y, z, const.BOTTOM_LEFT_CORNER)
             mesh.append(point)
         

--- a/tomo/protocols/protocol_mesh_from_segmentation.py
+++ b/tomo/protocols/protocol_mesh_from_segmentation.py
@@ -177,7 +177,7 @@ class ProtMeshFromSegmentation(EMProtocol, ProtTomoBase):
                            mesh: SetOfMeshes,
                            tomogram: Tomogram,
                            mask: np.ndarray ) -> None:
-        mask = (self.lowLimit.get() <= mask) and (mask <= self.highLimit.get())
+        mask = (self.lowLimit.get() <= mask) & (mask <= self.highLimit.get())
         self._processBinaryMask(
             mesh=mesh,
             tomogram=tomogram,

--- a/tomo/protocols/protocol_mesh_from_segmentation.py
+++ b/tomo/protocols/protocol_mesh_from_segmentation.py
@@ -23,44 +23,57 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
+import numpy as np
+import math
 
 from pwem.protocols import EMProtocol
+from pwem.objects import Set, Integer
+from pwem.emlib.image import ImageHandler
 
-import numpy as np
 from pyworkflow import BETA
-from pyworkflow.protocol.params import PointerParam, FloatParam
-from tomo.objects import SetOfMeshes, MeshPoint, SetOfTomoMasks
-import tomo.constants as const
+from pyworkflow.protocol.params import (PointerParam, FloatParam, 
+                                        BooleanParam, IntParam)
 
+from tomo.objects import (SetOfMeshes, MeshPoint, SetOfTomoMasks, TomoMask,
+                          SetOfTomograms, Tomogram)
 from tomo.protocols import ProtTomoBase
-import mrcfile
+import tomo.constants as const
 
 
 class ProtMeshFromSegmentation(EMProtocol, ProtTomoBase):
     """
-    Creates meshes based on segmentations (TomoMasks) voxels values.
+    Creates meshes based on segmentations or voxels values (TomoMasks).
     """
-    _label = 'meshes from tomoMask'
+    _label = 'meshes from tomo mask'
     _devStatus = BETA
-    # Output name
     _OUTPUT_NAME = 'Meshes'
     _possibleOutputs = {_OUTPUT_NAME: SetOfMeshes}
     listOfMeshCoords = {}
 
-    # --------------------------- DEFINE param functions ------------------------
+    # --------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
         form.addSection(label='Parameters')
 
-        form.addParam('tomoMasks',
-                      PointerParam,
-                      important=True,
-                      pointerClass=SetOfTomoMasks,
-                      label='Tomo Masks',
+        form.addParam('inputMasks', PointerParam, pointerClass=SetOfTomoMasks,
+                      label='Tomo Masks', important=True,
                       help='Set of tomo mask from which the meshes will be created')
-
+        form.addParam('inputTomograms', PointerParam, pointerClass=SetOfTomograms,
+                      label='Tomograms',
+                      help='Tomograms to which the meshes will be asotiated')
+        
+        form.addParam('segmentation', BooleanParam, label='Is input segmented',
+                      important=True, default=False,
+                      help='TODO')
+        
+        form.addParam('backgroundLabel', IntParam, label='Background label',
+                      condition='segmentation', default=0,
+                      help='Label in the segmentation to be considered as '
+                           'background')
+        
         line = form.addLine('Threshold to keep',
-                             help="Only the voxels between these two values will be considered to create the meshes.")
-
+                            condition='not segmentation',
+                            help="Only the voxels between these two values "
+                            "will be considered to create the meshes.")
         line.addParam('lowLimit', FloatParam, default=0.1, label='Lowest')
         line.addParam('highLimit', FloatParam, default=1, label='Highest')
 
@@ -68,83 +81,123 @@ class ProtMeshFromSegmentation(EMProtocol, ProtTomoBase):
                       FloatParam,
                       label='Percentage of density ',
                       default=5.0,
-                      help='This parameter goes from 0 - 100 and defines the percentage of voxel of the tomoMask that'
+                      help='This parameter goes from 0 - 100 and defines the '
+                           'percentage of voxel of the tomoMask that '
                            'will be considered as points of the mesh.')
 
-    # --------------------------- INSERT steps functions ------------------------
+    # --------------------------- INSERT steps functions -----------------------
     def _insertAllSteps(self):
+        tomograms: SetOfTomograms = self.inputTomograms.get()
 
-        for tm in self.tomoMasks.get():
-            tsId = tm.getTsId()
-            self._insertFunctionStep(self.createMeshesStep, tsId)
         self._insertFunctionStep(self.createOutputStep)
+        for tomogram in tomograms:
+            tsId = tomogram.getTsId()
+            self._insertFunctionStep(self.processTomogramStep, tsId)
+        self._insertFunctionStep(self.closeOutputStep)
 
-    # --------------------------- STEPS functions -------------------------------
-
-    def createMeshesStep(self, tsId):
-
-        settm = self.tomoMasks.get()
-        tomoMask = settm[{'_tsId': tsId}]
-
-        if tomoMask is None:
-            self.warning('TomoMask not found for tsId %s' % tsId)
-            return
-
-        tomoFn = tomoMask.getFileName()
-        mytomo = mrcfile.read(tomoFn)
-
-        candidates = (self.lowLimit.get() <= mytomo) & (mytomo <= self.highLimit.get())
-
-        coordinates = np.argwhere(candidates)
-
-        segmentedPoints = len(coordinates)
-        idxArray = np.arange(0, segmentedPoints)
-
-        # Randomize the order of the array and get the permutation indices
-        idxArrayPermutations = np.random.permutation(idxArray)
-
-        rho = self.density.get()/100.0
-        self.listOfMeshCoords[tsId] = coordinates[idxArrayPermutations[0:int(np.floor(segmentedPoints*rho))]]
-
+    # --------------------------- STEPS functions ------------------------------
 
     def createOutputStep(self):
-        inputTomos = self.tomoMasks.get()
-        outSet = self._createSetOfMeshes(inputTomos)
-        sampling = inputTomos.getSamplingRate()
-        outSet.setSamplingRate(sampling)
-        outSet.setBoxSize(10)
-        grId = 1
-        for tomo in inputTomos.iterItems():
-            tsId = tomo.getTsId()
-            listOfCoords = self.listOfMeshCoords[tsId]
-            x = listOfCoords[:,2]
-            y = listOfCoords[:,1]
-            z = listOfCoords[:,0]
+        tomograms = self.inputTomograms
+    
+        meshes: SetOfMeshes = self._createSetOfMeshes(tomograms)
+        meshes.setSamplingRate(tomograms.get().getSamplingRate())
+        meshes.setStreamState(Set.STREAM_OPEN)
+ 
+        self._defineOutputs(**{self._OUTPUT_NAME: meshes})
+        self._defineSourceRelation(self.inputMasks, tomograms)
+        self._defineSourceRelation(self.inputTomograms, tomograms)
+        
+        self.baseGroupId = Integer(1)
+ 
+    def processTomogramStep(self, tsId):
+        mask = self._getInputMask(tsId)
+        if mask is not None:
+            tomogram = self._getInputTomogram(tsId)
+            outputMeshes = getattr(self, self._OUTPUT_NAME)
+            maskData = None # TODO
+    
+            if self.segmentation:
+                self._processSegmentation(
+                    mesh=outputMeshes,
+                    tomogram=tomogram,
+                    segmentation=maskData
+                )
+            else:
+                self._processSmoothMask(
+                    mesh=outputMeshes,
+                    tomogram=tomogram,
+                    mask=maskData
+                )
+    
+    def closeOutputStep(self):
+        self._closeOutputSet()
 
-            for idx in range(0,len(x)):
-                mesh = MeshPoint()
-                mesh.setVolume(tomo)
-                mesh.setPosition(x[idx], y[idx], z[idx], const.BOTTOM_LEFT_CORNER)
-                mesh.setGroupId(grId)
-                outSet.append(mesh)
-            grId += 1
-        outSet.setPrecedents(inputTomos)
-        self._defineOutputs(**{self._OUTPUT_NAME:outSet})
-        self._defineSourceRelation(inputTomos, outSet)
+    # --------------------------- UTILS functions ------------------------------
+    def _getInputMask(self, tsId: str) -> TomoMask:
+        masks = self.inputMasks.get()
+        return masks[{TomoMask.TS_ID_FIELD: tsId}]
 
-    # --------------------------- INFO functions ------------------------------
-    def _methods(self):
-        message = 'This is a Scipiontomo method'
-        return [message]
+    def _getInputTomogram(self, tsId: str) -> Tomogram:
+        tomos = self.inputTomograms.get()
+        return tomos[{Tomogram.TS_ID_FIELD: tsId}]
+    
+    def _loadMask(self, mask: TomoMask) -> np.ndarray:
+        ih = ImageHandler()
+        image = ih.read(mask)
+        return image.getData()
 
+    # --------------------------- INFO functions -------------------------------
     def _validate(self):
         errors = []
+        
         if self.density.get()>100:
-            errors.append('The density must be lesser than zero')
+            errors.append('The density must be lesser than 100')
         if self.density.get()<0.0:
             errors.append('The density must be greater than zero')
+            
         return errors
 
-    def _summary(self):
-        summary = ['A set of meshes has been created']
-        return summary
+    def _processSegmentation(self, 
+                             mesh: SetOfMeshes, 
+                             tomogram: Tomogram, 
+                             segmentation: np.ndarray ) -> None:
+        labels = np.unique(segmentation)
+        for label in labels:
+            if label != self.backgroundLabel.get():
+                mask = (segmentation == label)
+                self._processBinaryMask(
+                    mesh=mesh, 
+                    tomogram=tomogram,
+                    mask=mask
+                )
+    
+    def _processSmoothMask(self,
+                           mesh: SetOfMeshes,
+                           tomogram: Tomogram,
+                           mask: np.ndarray ) -> None:
+        mask = (self.lowLimit.get() <= mask) and (mask <= self.highLimit.get())
+        self._processBinaryMask(
+            mesh=mesh,
+            tomogram=tomogram,
+            mask=mask
+        )
+                
+    def _processBinaryMask(self,
+                           mesh: SetOfMeshes,
+                           tomogram: Tomogram,
+                           mask: np.ndarray ):
+        probability = self.density.get / 100
+        coordinates = np.argwhere(mask)
+        indices = np.arange(0, len(coordinates))
+        nPoints = math.floor(probability*len(indices))
+        selection = np.random.choice(indices, size=nPoints, replace=False)
+        
+        point = MeshPoint()
+        point.setVolume(tomogram)
+        point.setGroupId(self.baseGroupId)
+        for z, y, x in coordinates[selection,:]:
+            point.setPosition(x, y, z, const.BOTTOM_LEFT_CORNER)
+            mesh.append(point)
+        
+        self.baseGroupId.increment()


### PR DESCRIPTION
Refactored mesh from segmentation protocol to keep track of segmentation labels when the input segmentation is semantic. In addition, the set of meshes was previously assotiated to a SetOfMask, which is incorrect for any practical use case of this object (it should be assotiated to a SetOfTomograms)