### PR TITLE
Fixed issues with CBOX protocol_import_coordinates

### DIFF
--- a/tomo/convert/convert.py
+++ b/tomo/convert/convert.py
@@ -57,11 +57,13 @@ class TomoImport:
 
 class EmTableCoordImport:
 
-    def __init__(self, block, xField, yField, zField):
+    def __init__(self, block, xField, yField, zField, wField=None,hField=None):
         self.block = block
         self.xField = xField
         self.yField = yField
         self.zField = zField
+        self.hField = hField
+        self.wField = wField
     def importCoordinates3D(self, fileName, addCoordinate):
         from tomo.objects import Coordinate3D
 
@@ -72,8 +74,12 @@ class EmTableCoordImport:
         for row in md:
             print(row)
             x = row.get(self.xField)
+            if self.wField is not None:
+                x += row.get(self.wField)/2
             print(x)
             y = row.get(self.yField)
+            if self.hField is not None:
+                y += row.get(self.hField)/2
             z = row.get(self.zField)
             coord = Coordinate3D()
             addCoordinate(coord, x, y, z)

--- a/tomo/protocols/protocol_import_coordinates.py
+++ b/tomo/protocols/protocol_import_coordinates.py
@@ -262,7 +262,7 @@ class ProtImportCoordinates3D(ProtTomoImportFiles):
             return readDynCoord
 
         elif importFrom == IMPORT_FROM_CBOX:
-            return EmTableCoordImport("cryolo", "CoordinateX", "CoordinateY", "CoordinateZ")
+            return EmTableCoordImport("cryolo", "CoordinateX", "CoordinateY", "CoordinateZ", "Width", "Height")
 
         elif importFrom == IMPORT_FROM_TXT:
             return TomoImport(self)


### PR DESCRIPTION
Cryolo `.cbox` X,Y coordinates are relative to the corner of the box defined by Width and Height.

I added a shift by half the Width and Height to X and Y to fix the problem.

We can now import centered coordinated from cryolo.