### PR TITLE
feat(assignTransformation): add unit tests for transformation assignment (20260512)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
-V3.12.6:
-  - Fix: Fixing an error crating subsets
-  - Fix: Prevent duplicated object insertion
+V3.11.6:
+ Users:
+  - Fix: Fixing an error crating subsets.
+  - Fix: Prevent duplicated object insertion.
+  - Protocol assign transformation to TS: improve the streaming.
+ Developers:
+  - Expand the TCL.
+  - Add tests to protocol assign transformation to TS.
 v3.11.5:
  Users:
   - Protocol meshes from segmentation: protocol parallelized.

--- a/tomo/protocols/protocol_assignTransformationTS.py
+++ b/tomo/protocols/protocol_assignTransformationTS.py
@@ -30,7 +30,7 @@ import traceback
 import typing
 from collections import Counter
 from enum import Enum
-from typing import List, Union
+from typing import List, Union, Dict
 import numpy as np
 from pwem.objects import Transform
 from pyworkflow import BETA
@@ -38,6 +38,7 @@ from pwem.protocols import EMProtocol
 from pyworkflow.object import Pointer, Set
 from pyworkflow.protocol import STEPS_PARALLEL, ProtStreamingBase, PointerParam
 from pyworkflow.utils import Message, cyanStr, redStr, yellowStr
+from pyworkflow.utils.retry_streaming import retry_on_sqlite_lock
 from tomo.objects import SetOfTiltSeries, TiltSeries, TiltImage
 
 logger = logging.getLogger(__name__)
@@ -117,7 +118,7 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtStreamingBase):
                                   and ts.getSize() > 0}  # Avoid processing empty TS
             tsTo2ProcessDict = {tsId: ts.clone() for ts in inTsSetTo.iterItems()
                                 if (tsId := ts.getTsId()) in nonProcessedTsIdsTo  # Only not processed tsIds (to)
-                                and ts.getSize() > 0}  # Avoid processing empty CTFs
+                                and ts.getSize() > 0}  # Avoid processing empty TS
 
             for tsId, tsFrom in tsFrom2ProcessDict.items():
                 tsTo = tsTo2ProcessDict.get(tsId, None)
@@ -149,6 +150,14 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtStreamingBase):
     def assignTrMatStep(self, tsId: str, tsFrom: TiltSeries, tsTo: TiltSeries):
         logger.info(cyanStr(f"tsId = {tsId} - assigning alignment..."))
         try:
+            self._registerOutput(tsId, tsFrom, tsTo)
+        except Exception as e:
+            logger.error(redStr(f'tsId = {tsId} -> failed: {e}'))
+            logger.error(traceback.format_exc())
+
+    @retry_on_sqlite_lock(log=logger)
+    def _registerOutput(self, tsId: str, tsFrom: TiltSeries, tsTo: TiltSeries):
+        with self._lock:
             outTsSet = self.getOutTsSet()
             newTs = TiltSeries(tsId=tsId)
             newTs.copyInfo(tsTo)
@@ -167,16 +176,16 @@ class ProtAssignTransformationMatrixTiltSeries(EMProtocol, ProtStreamingBase):
                 newTs.append(newTi)
 
             newTs.setDim(tsTo.getDim())
+            newTs.setAlignment2D()
             newTs.write()
             outTsSet.update(newTs)
             outTsSet.write()
             self._store()
 
-        except Exception as e:
-            logger.error(redStr(f'tsId = {tsId} -> failed: {e}'))
-            logger.error(traceback.format_exc())
-
-    def _processTiltImage(self, tiTo, fromTsAcqDict, matchingAcqOrders):
+    def _processTiltImage(self,
+                          tiTo: TiltImage,
+                          fromTsAcqDict: Dict[int, TiltImage],
+                          matchingAcqOrders: typing.Set[int]):
         acqOrder = tiTo.getAcquisitionOrder()
 
         if acqOrder in matchingAcqOrders:

--- a/tomo/tests/test_assign_transformation_ts.py
+++ b/tomo/tests/test_assign_transformation_ts.py
@@ -1,0 +1,221 @@
+# *
+# * Authors:     Scipion Team
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion-users@lists.sourceforge.net'
+# *
+# **************************************************************************
+from typing import Optional, Type
+
+from pwem import ALIGN_2D
+from pyworkflow.tests import setupTestProject, DataSet
+from pyworkflow.utils import magentaStr, cyanStr, weakImport
+from tomo.objects import SetOfTiltSeries
+from tomo.protocols import ProtImportTs
+from tomo.protocols.protocol_assignTransformationTS import ProtAssignTransformationMatrixTiltSeries
+from tomo.tests import RE4_STA_TUTO, DataSetRe4STATuto, TS_03, TS_54
+from tomo.tests.test_base_centralized_layer import TestBaseCentralizedLayer
+
+with weakImport("imod"):
+    from imod.constants import OUTPUT_TILTSERIES_NAME
+    from imod.protocols import ProtImodImportTransformationMatrix, ProtImodTsNormalization
+
+
+class TestAssignTransformationTS(TestBaseCentralizedLayer):
+    ds = None
+    binFactor = 2
+    exclusionWords = None
+    tsSetNoAlignment = None
+    tsSetWithAlignment = None
+    tsSetBinned = None
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.ds = DataSet.getDataSet(RE4_STA_TUTO)
+        cls._runPrevProtocols()
+
+    @classmethod
+    def _runPrevProtocols(cls):
+        print(cyanStr('\n--------------------------------- RUNNING PREVIOUS PROTOCOLS '
+                      '---------------------------------'))
+        cls.exclusionWords = DataSetRe4STATuto.exclusionWordsTs03ts54.value
+        # Import TS_03 + TS_54 once (no alignment) — reused across all tests
+        cls.tsSetNoAlignment = cls._runImportTs(exclusionWords=cls.exclusionWords)
+        # Derive a set with alignment (transform matrices imported via IMOD)
+        cls.tsSetWithAlignment = cls._runImportTrMatrix(cls.tsSetNoAlignment)
+        # Derive a binned set via IMOD preprocessing (bin 2)
+        cls.tsSetBinned = cls._runBinTs(cls.tsSetNoAlignment, binning=cls.binFactor)
+        print(cyanStr('\n-------------------------------- PREVIOUS PROTOCOLS FINISHED '
+                      '---------------------------------'))
+
+    @classmethod
+    def _runImportTs(cls, exclusionWords: Optional[str] = None):
+        print(magentaStr("\n==> Importing the tilt series:"))
+        protTsImport = cls.newProtocol(ProtImportTs,
+                                       filesPath=cls.ds.getFile(DataSetRe4STATuto.tsPath.value),
+                                       filesPattern=DataSetRe4STATuto.tsPattern.value,
+                                       exclusionWords=exclusionWords,
+                                       anglesFrom=2,  # From tlt file
+                                       voltage=DataSetRe4STATuto.voltage.value,
+                                       magnification=DataSetRe4STATuto.magnification.value,
+                                       sphericalAberration=DataSetRe4STATuto.sphericalAb.value,
+                                       amplitudeContrast=DataSetRe4STATuto.amplitudeContrast.value,
+                                       samplingRate=DataSetRe4STATuto.unbinnedPixSize.value,
+                                       doseInitial=DataSetRe4STATuto.initialDose.value,
+                                       dosePerFrame=DataSetRe4STATuto.dosePerTiltImgWithTltFile.value,
+                                       tiltAxisAngle=DataSetRe4STATuto.tiltAxisAngle.value)
+        cls.launchProtocol(protTsImport)
+        tsImported = getattr(protTsImport, protTsImport.OUTPUT_NAME, None)
+        return tsImported
+
+    @classmethod
+    def _runImportTrMatrix(cls, inTsSet: SetOfTiltSeries) -> Optional[SetOfTiltSeries]:
+        print(magentaStr("\n==> Importing the TS' transformation matrices with IMOD:"))
+        protImportTrMatrix = cls.newProtocol(ProtImodImportTransformationMatrix,
+                                             filesPath=cls.ds.getFile(DataSetRe4STATuto.tsPath.value),
+                                             filesPattern=DataSetRe4STATuto.transformPattern.value,
+                                             inputSetOfTiltSeries=inTsSet)
+        cls.launchProtocol(protImportTrMatrix)
+        outTsSet = getattr(protImportTrMatrix, OUTPUT_TILTSERIES_NAME, None)
+        return outTsSet
+
+    @classmethod
+    def _runBinTs(cls, inTsSet: SetOfTiltSeries, binning: int = 2) -> Optional[SetOfTiltSeries]:
+        print(magentaStr(f"\n==> Binning the tilt-series with IMOD (bin={binning}):"))
+        protTSNormalization = cls.newProtocol(ProtImodTsNormalization,
+                                              inputSetOfTiltSeries=inTsSet,
+                                              binning=binning)
+        cls.launchProtocol(protTSNormalization)
+        outTsSet = getattr(protTSNormalization, OUTPUT_TILTSERIES_NAME, None)
+        return outTsSet
+
+    @classmethod
+    def _runAssignTransformation(cls,
+                                 fromTsSet: SetOfTiltSeries,
+                                 toTsSet: SetOfTiltSeries,
+                                 objLabel: str = 'assign transformation') \
+            -> Type[ProtAssignTransformationMatrixTiltSeries]:
+
+        print(magentaStr("\n==> Assigning transformation matrices:"))
+        protAssign = cls.newProtocol(ProtAssignTransformationMatrixTiltSeries,
+                                     getTMSetOfTiltSeries=fromTsSet,
+                                     setTMSetOfTiltSeries=toTsSet)
+        protAssign.setObjLabel(objLabel)
+        cls.launchProtocol(protAssign)
+        return protAssign
+
+    def test_assignTransformation_sameSRate(self):
+        """Test assigning transformation matrices between two sets of tilt series
+        with the same sampling rate. The 'from' set has alignment (imported
+        transformation matrices) and the 'to' set is a plain import without
+        alignment. The output should have alignment assigned."""
+        print(magentaStr("\n==> TEST: Assign transformation with the same sampling rate"))
+        protAssign = self._runAssignTransformation(
+            self.tsSetWithAlignment, self.tsSetNoAlignment,
+            objLabel='assign TM same sRate')
+
+        outputTsSet = getattr(protAssign, protAssign._possibleOutputs.tiltSeries.name, None)
+        self.assertIsNotNone(outputTsSet, "No output tilt series set was generated.")
+
+        tsIdList = (TS_03, TS_54)
+        testAcqObjDict, expectedDimensionsDict, anglesCountDict = \
+            DataSetRe4STATuto.genTestTsDicts(tsIdList=tsIdList)
+
+        self.checkTiltSeries(outputTsSet,
+                             expectedSetSize=2,
+                             expectedSRate=DataSetRe4STATuto.unbinnedPixSize.value,
+                             expectedDimensions=expectedDimensionsDict,
+                             testAcqObj=testAcqObjDict,
+                             anglesCount=anglesCountDict,
+                             hasAlignment=True,
+                             alignment=ALIGN_2D,
+                             presentTsIds=[TS_03, TS_54])
+
+    def test_assignTransformation_differentSRate(self):
+        """Test assigning transformation matrices between two sets of tilt series
+        with different sampling rates. The 'from' set has alignment at the unbinned
+        sampling rate (1.35 A/pix), and the 'to' set is preprocessed with IMOD
+        (bin 2 -> 2.7 A/pix), producing genuinely binned files with correct
+        sampling rate and dimensions. Verifies that the protocol correctly scales
+        the transformation matrix shifts by the sampling rate ratio
+        (toSRate / fromSRate = 2.0)."""
+        print(magentaStr("\n==> TEST: Assign transformation with different sampling rates"))
+        unbinnedSRate = DataSetRe4STATuto.unbinnedPixSize.value  # 1.35
+        binnedSRate = unbinnedSRate * self.binFactor  # 2.7
+
+        # Verify sampling rates are genuinely different before running the protocol
+        self.assertAlmostEqual(self.tsSetWithAlignment.getSamplingRate(), unbinnedSRate,
+                               delta=0.01,
+                               msg="'from' set sampling rate is not the expected unbinned value.")
+        self.assertAlmostEqual(self.tsSetBinned.getSamplingRate(), binnedSRate,
+                               delta=0.01,
+                               msg="'to' set sampling rate is not the expected binned value.")
+        self.assertNotAlmostEqual(self.tsSetWithAlignment.getSamplingRate(),
+                                  self.tsSetBinned.getSamplingRate(),
+                                  delta=0.01,
+                                  msg="Sampling rates should differ between 'from' and 'to' sets.")
+
+        protAssign = self._runAssignTransformation(
+            self.tsSetWithAlignment, self.tsSetBinned,
+            objLabel='assign TM diff sRate')
+
+        outputTsSet = getattr(protAssign, protAssign._possibleOutputs.tiltSeries.name, None)
+        self.assertIsNotNone(outputTsSet, "No output tilt series set was generated.")
+
+        tsIdList = (TS_03, TS_54)
+        testAcqObjDict, expectedDimensionsDict, anglesCountDict = \
+            DataSetRe4STATuto.genTestTsDicts(tsIdList=tsIdList,
+                                             binFactor=self.binFactor,
+                                             isImod=True)
+
+        self.checkTiltSeries(outputTsSet,
+                             expectedSetSize=2,
+                             expectedSRate=binnedSRate,
+                             expectedDimensions=expectedDimensionsDict,
+                             testAcqObj=testAcqObjDict,
+                             anglesCount=anglesCountDict,
+                             hasAlignment=True,
+                             alignment=ALIGN_2D,
+                             presentTsIds=[TS_03, TS_54])
+
+        # Check that the matrix shifts scale were properly scaled
+        self.checkTrMatrixShiftsScale(self.tsSetWithAlignment, outputTsSet)
+
+    def test_assignTransformation_validate_noAlignment(self):
+        """Test that the protocol's validation correctly reports errors when
+        the 'from' set has no alignment (no transformation matrices).
+        The protocol requires the 'from' set to have alignment, so validate()
+        must return meaningful error messages without launching the protocol."""
+        print(magentaStr("\n==> TEST: Validation - 'from' TS without alignment"))
+        protAssign = self.newProtocol(ProtAssignTransformationMatrixTiltSeries,
+                                      getTMSetOfTiltSeries=self.tsSetNoAlignment,
+                                      setTMSetOfTiltSeries=self.tsSetNoAlignment)
+        protAssign.setObjLabel('assign TM no alignment (validate)')
+
+        # Validate directly — no protocol launch, no exception
+        errors = protAssign.validate()
+        self.assertGreater(len(errors), 0,
+                           "Protocol should report validation errors when 'from' set "
+                           "has no alignment.")
+        errorMsg = '\n'.join(errors)
+        self.assertIn("transformation matrix", errorMsg,
+                      f"Validation error should mention missing transformation "
+                      f"matrix. Got: {errorMsg}")

--- a/tomo/tests/test_base_centralized_layer.py
+++ b/tomo/tests/test_base_centralized_layer.py
@@ -337,6 +337,56 @@ class TestBaseCentralizedLayer(BaseTest):
                         msg=f'Tilt-series {ts.getTsId()}: origin values [originX, originY, originZ] are different than '
                             f'the expected within tolerance {originTolAngst} Å.\n{testOrigin} != \n{origin}')
 
+    def checkTrMatrixShiftsScale(self,
+                                 inTsSet: SetOfTiltSeries,
+                                 outTsSet: SetOfTiltSeries,
+                                 tolShiftsScaling: float = 0.1) -> None:
+        """Verify that transformation matrix shifts were scaled by the sampling rate ratio.
+
+        :param inTsSet: input SetOfTiltSeries containing the original transformation matrices.
+        :param outTsSet: output SetOfTiltSeries whose transformation matrices are expected to contain the scaled shifts.
+        :param tolShiftsScaling: tolerance allowed when checking that the shifts in the transformation matrices
+        have been properly scaled between the input and output tilt-series sets.
+        """
+        self.assertTrue(inTsSet.hasAlignment() and outTsSet.hasAlignment(),
+                        msg='Both sets of tilt series must have alignment information to check the shifts scaling')
+        inSRate = inTsSet.getSamplingRate()
+        outSRate = outTsSet.getSamplingRate()
+        sRateRatio = outSRate / inSRate
+
+        inTsIds = set(inTsSet.getTSIds())
+        outTsIds = set(outTsSet.getTSIds())
+        commonTsIds = inTsIds & outTsIds
+        self.assertTrue(len(commonTsIds) > 0, msg='The introduced sets do not have common tsIds.')
+        inTsSetDict = {tsId: ts.clone() for ts in inTsSet.iterItems() if (tsId := ts.getTsId()) in commonTsIds}
+        outTsSetDict = {tsId: ts.clone() for ts in outTsSet.iterItems() if (tsId := ts.getTsId()) in commonTsIds}
+
+        for tsId in commonTsIds:
+            inTs = inTsSetDict[tsId]
+            outTs = outTsSetDict[tsId]
+            inTiDict = {ti.getAcquisitionOrder(): ti.clone() for ti in inTs}
+            outTiDict = {ti.getAcquisitionOrder(): ti.clone() for ti in outTs}
+            commonAcqOrders = set(inTiDict.keys()) & set(outTiDict.keys())
+
+            for acqOrder in commonAcqOrders:
+                outTi = outTiDict[acqOrder]
+                if outTi.isEnabled():
+                    inTi = inTiDict[outTi.getAcquisitionOrder()]
+                    inTiMatrix = inTi.getTransform().getMatrix()
+                    outTiMatrix = outTi.getTransform().getMatrix()
+                    self.assertAlmostEqual(
+                        outTiMatrix[0][2],
+                        inTiMatrix[0][2] / sRateRatio,
+                        delta=tolShiftsScaling,
+                        msg=f"X shift scaling incorrect for tsId={tsId}, "
+                            f"acqOrder={outTi.getAcquisitionOrder()}")
+                    self.assertAlmostEqual(
+                        outTiMatrix[1][2],
+                        inTiMatrix[1][2] / sRateRatio,
+                        delta=tolShiftsScaling,
+                        msg=f"Y shift scaling incorrect for tsId={tsId}, "
+                            f"acqOrder={outTi.getAcquisitionOrder()}")
+
     # TOMO ACQUISITION #################################################################################################
     def checkTomoAcquisition(self, testAcq: Union[TomoAcquisition, dict],
                              currentAcq: TomoAcquisition,


### PR DESCRIPTION
feat(assignTransformation): add unit tests for transformation assignment (20260512)

- Introduced unit tests for the protocol that assigns transformation matrices between tilt series.
- Added checks to validate both same and different sampling rates.
- Enhanced validation to ensure proper error reporting when no alignment is present in the 'from' tilt series.
- Implemented scaling checks for transformation matrix shifts based on sampling rate ratios.
```